### PR TITLE
feat: opensaas — consuelo SDK monorepo scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,47 +1,6 @@
-# Agent workflow runtime files (auto-generated)
-.agent/claude-progress.txt
-.agent/metrics.json
-.agent/research/*.md
-!.agent/research/.gitkeep
-.agent/.sentry-imported-ids
-
-# Hook state files
-.claude/hooks/loop-state.json
-
-# Beads database (each project has its own)
-.beads/
-
-# Test results (if using Playwright or similar)
-e2e/agent-results/
-test-results/
-
-# Node modules (if running tests locally)
 node_modules/
-
-# Python virtual environment
-venv/
-__pycache__/
-*.pyc
-
-# OS files
-.DS_Store
-Thumbs.db
-
-# IDE files
-.vscode/
-.idea/
-*.swp
-*.swo
-
-# Environment files (never commit secrets)
+dist/
+.turbo/
+*.tsbuildinfo
 .env
 .env.local
-.env.*.local
-
-# Session files (may contain API keys and sensitive data)
-agents/*/sessions/
-
-# Configuration files with secrets
-openclaw.json
-opencode.json
-.agent/config.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 *.tsbuildinfo
 .env
 .env.local
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "typecheck": "turbo typecheck"
   },
   "devDependencies": {
+    "@types/node": "^25.2.2",
     "turbo": "^2",
-    "typescript": "^5.7"
+    "typescript": "5.7"
   },
   "packageManager": "npm@10.9.2",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "consuelo-sdk",
+  "private": true,
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
+  "scripts": {
+    "build": "turbo build",
+    "dev": "turbo dev",
+    "lint": "turbo lint",
+    "clean": "turbo clean",
+    "typecheck": "turbo typecheck"
+  },
+  "devDependencies": {
+    "turbo": "^2",
+    "typescript": "^5.7"
+  },
+  "packageManager": "npm@10.9.2",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@consuelo/analytics",
+  "version": "0.0.1",
+  "description": "Call transcription, sentiment analysis, and performance metrics",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -11,6 +11,14 @@
     "typecheck": "tsc --noEmit"
   },
   "license": "MIT",
+  "peerDependencies": {
+    "openai": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "openai": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -1,0 +1,133 @@
+import type { AnalyticsConfig, Message, AnalyzeCallOptions, MetricsQuery, AggregateMetrics } from './types.js';
+import type { CallAnalytics, SentimentAnalysis, PerformanceMetrics } from './schemas/models.js';
+
+const ANALYTICS_PROMPT = (transcript: string) => `Analyze this sales call transcript and provide detailed analytics:
+
+CALL TRANSCRIPT:
+${transcript}
+
+INSTRUCTIONS:
+You are a sales coach analyzing a sales call. Provide objective, actionable analysis.
+Respond with ONLY a JSON object, no markdown.
+
+Return JSON with this structure:
+{
+  "key_moments": [{"timestamp": "MM:SS", "type": "type", "description": "desc", "transcript_snippet": "snippet"}],
+  "sentiment_analysis": {"customer_sentiment": "positive|neutral|negative|mixed", "engagement_level": "high|medium|low", "objections_raised": [], "buying_signals": []},
+  "performance_metrics": {"talk_ratio": 0.6, "questions_asked": 5, "objections_handled": 0, "next_steps_established": true},
+  "overall_score": 85,
+  "strengths": ["..."],
+  "improvement_areas": ["..."],
+  "action_items": ["..."]
+}`;
+
+/** Coerce a value that might be a string into a string array */
+function toStringArray(val: unknown): string[] {
+  if (Array.isArray(val)) return val.map(String);
+  if (typeof val === 'string' && val.trim() && val.toLowerCase() !== 'none') return [val];
+  return [];
+}
+
+/** Extract JSON from an LLM response that may contain markdown fences */
+function extractJson(text: string): Record<string, unknown> {
+  const fenced = text.match(/```json\s*([\s\S]*?)\s*```/);
+  const raw = fenced ? fenced[1] : text.match(/\{[\s\S]*\}/)?.[0];
+  if (!raw) throw new Error('No JSON found in analytics response');
+  return JSON.parse(raw);
+}
+
+/**
+ * Core Analytics class — generates call analytics via LLM.
+ */
+export class Analytics {
+  private config: AnalyticsConfig;
+
+  constructor(config: AnalyticsConfig = {}) {
+    this.config = config;
+  }
+
+  /** Generate structured analytics for a call transcript */
+  async analyzeCall(conversation: Message[], options: AnalyzeCallOptions = {}): Promise<CallAnalytics> {
+    const transcript = conversation.map((m) => `${m.role.toUpperCase()}: ${m.content}`).join('\n');
+    if (!transcript) throw new Error('Empty transcript');
+
+    const apiKey = this.config.apiKey ?? process.env.GROQ_API_KEY ?? process.env.OPENAI_API_KEY;
+    if (!apiKey) throw new Error('No API key provided');
+
+    const isOpenAI = this.config.provider === 'openai';
+    const baseURL = isOpenAI ? undefined : 'https://api.groq.com/openai/v1';
+    const model = this.config.model ?? (isOpenAI ? 'gpt-4o-mini' : 'llama-3.1-8b-instant');
+
+    const { default: OpenAI } = await import('openai');
+    const client = new OpenAI({ apiKey, baseURL });
+
+    const resp = await client.chat.completions.create({
+      model,
+      messages: [{ role: 'user', content: ANALYTICS_PROMPT(transcript) }],
+      temperature: 0.3,
+      max_tokens: 1500,
+    });
+
+    const text = resp.choices[0]?.message?.content ?? '';
+    const data = extractJson(text);
+
+    const sentiment = (data.sentiment_analysis ?? {}) as Record<string, unknown>;
+    const metrics = (data.performance_metrics ?? {}) as Record<string, unknown>;
+
+    // Parse talk_ratio — might be string like "70%"
+    let talkRatio = 0.6;
+    const rawRatio = metrics.talk_ratio;
+    if (typeof rawRatio === 'number') talkRatio = rawRatio;
+    else if (typeof rawRatio === 'string') {
+      const m = rawRatio.match(/(\d+)%?/);
+      if (m) talkRatio = parseFloat(m[1]) > 1 ? parseFloat(m[1]) / 100 : parseFloat(m[1]);
+    }
+
+    const now = new Date().toISOString();
+
+    return {
+      call_sid: options.callSid ?? '',
+      user_id: options.userId ?? '',
+      phone_number: options.phoneNumber ?? '',
+      call_date: options.callDate ?? now.split('T')[0],
+      key_moments: ((data.key_moments as unknown[]) ?? []).map((m: any) => ({
+        timestamp: m.timestamp ?? '00:00',
+        type: m.type ?? 'other',
+        description: m.description ?? '',
+        transcript_snippet: m.transcript_snippet ?? '',
+      })),
+      sentiment_analysis: {
+        customer_sentiment: (sentiment.customer_sentiment as string)?.toLowerCase() ?? 'neutral',
+        engagement_level: (sentiment.engagement_level as string)?.toLowerCase() ?? 'medium',
+        objections_raised: toStringArray(sentiment.objections_raised),
+        buying_signals: toStringArray(sentiment.buying_signals),
+      } as SentimentAnalysis,
+      performance_metrics: {
+        talk_ratio: talkRatio,
+        questions_asked: Number(metrics.questions_asked) || 0,
+        objections_handled: Number(metrics.objections_handled) || 0,
+        next_steps_established: Boolean(metrics.next_steps_established),
+        call_duration_minutes: conversation.length * 0.5,
+      } as PerformanceMetrics,
+      overall_score: Number(data.overall_score) || 0,
+      strengths: toStringArray(data.strengths),
+      improvement_areas: toStringArray(data.improvement_areas),
+      action_items: toStringArray(data.action_items),
+      generated_at: now,
+    };
+  }
+
+  /** Compute aggregate metrics from a set of analytics results */
+  static aggregateMetrics(results: CallAnalytics[]): AggregateMetrics {
+    if (!results.length) return { totalCalls: 0, avgScore: 0, avgTalkRatio: 0, totalQuestionsAsked: 0, totalObjectionsHandled: 0, callsWithNextSteps: 0 };
+    const n = results.length;
+    return {
+      totalCalls: n,
+      avgScore: results.reduce((s, r) => s + r.overall_score, 0) / n,
+      avgTalkRatio: results.reduce((s, r) => s + r.performance_metrics.talk_ratio, 0) / n,
+      totalQuestionsAsked: results.reduce((s, r) => s + r.performance_metrics.questions_asked, 0),
+      totalObjectionsHandled: results.reduce((s, r) => s + r.performance_metrics.objections_handled, 0),
+      callsWithNextSteps: results.filter((r) => r.performance_metrics.next_steps_established).length,
+    };
+  }
+}

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,11 +1,24 @@
-// @consuelo/analytics
-// Call transcription, sentiment analysis, and performance metrics
+// Core
+export { Analytics } from './analytics.js';
 
+// Transcription
+export { processTranscriptionEvent, aggregateTranscript } from './transcription.js';
+
+// Schemas
+export type {
+  CallAnalytics,
+  KeyMoment,
+  SentimentAnalysis,
+  PerformanceMetrics,
+} from './schemas/models.js';
+
+// Types
 export type {
   AnalyticsConfig,
-  CallAnalytics,
-  SentimentAnalysis,
-  KeyMoment,
-  PerformanceMetrics,
+  Message,
   TranscriptEntry,
-} from "./types";
+  AnalyzeCallOptions,
+  MetricsQuery,
+  AggregateMetrics,
+  AnalyticsStore,
+} from './types.js';

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,0 +1,11 @@
+// @consuelo/analytics
+// Call transcription, sentiment analysis, and performance metrics
+
+export type {
+  AnalyticsConfig,
+  CallAnalytics,
+  SentimentAnalysis,
+  KeyMoment,
+  PerformanceMetrics,
+  TranscriptEntry,
+} from "./types";

--- a/packages/analytics/src/schemas/models.ts
+++ b/packages/analytics/src/schemas/models.ts
@@ -1,0 +1,38 @@
+/** Structured output schemas — mirrors monolith pydantic models */
+
+export interface KeyMoment {
+  timestamp: string; // "MM:SS"
+  type: 'objection' | 'buying_signal' | 'price_discussion' | 'next_steps' | 'closing_attempt' | string;
+  description: string;
+  transcript_snippet: string;
+}
+
+export interface SentimentAnalysis {
+  customer_sentiment: 'positive' | 'neutral' | 'negative' | 'mixed';
+  engagement_level: 'high' | 'medium' | 'low';
+  objections_raised: string[];
+  buying_signals: string[];
+}
+
+export interface PerformanceMetrics {
+  talk_ratio: number; // 0-1
+  questions_asked: number;
+  objections_handled: number;
+  next_steps_established: boolean;
+  call_duration_minutes: number;
+}
+
+export interface CallAnalytics {
+  call_sid: string;
+  user_id: string;
+  phone_number: string;
+  call_date: string;
+  key_moments: KeyMoment[];
+  sentiment_analysis: SentimentAnalysis;
+  performance_metrics: PerformanceMetrics;
+  overall_score: number; // 0-100
+  strengths: string[];
+  improvement_areas: string[];
+  action_items: string[];
+  generated_at: string; // ISO timestamp
+}

--- a/packages/analytics/src/transcription.ts
+++ b/packages/analytics/src/transcription.ts
@@ -1,0 +1,51 @@
+import type { TranscriptEntry, Message } from './types.js';
+
+/**
+ * Maps a Twilio transcription track to a conversation role.
+ */
+function trackToRole(track: string): TranscriptEntry['role'] {
+  const t = track?.toLowerCase() ?? '';
+  if (t === 'inbound' || t === 'inbound_track') return 'sales_rep';
+  if (t === 'outbound' || t === 'outbound_track') return 'customer';
+  return 'unknown';
+}
+
+/**
+ * Process a Twilio real-time transcription webhook event
+ * and return a structured TranscriptEntry.
+ */
+export function processTranscriptionEvent(form: Record<string, string>): TranscriptEntry | null {
+  if (form.TranscriptionEvent !== 'transcription-content') return null;
+
+  const dataStr = form.TranscriptionData;
+  if (!dataStr) return null;
+
+  const data = JSON.parse(dataStr);
+  const transcript = data.transcript as string | undefined;
+  if (!transcript) return null;
+
+  const callSid = form.CallSid ?? '';
+  const track = form.Track ?? '';
+  const ts = Date.now();
+
+  return {
+    id: `${callSid}_${track}_${ts}`,
+    callSid,
+    track,
+    transcript,
+    final: form.Final === 'true',
+    stability: form.Stability,
+    timestamp: new Date().toISOString(),
+    role: trackToRole(track),
+  };
+}
+
+/**
+ * Aggregate individual transcript entries into a conversation array.
+ */
+export function aggregateTranscript(entries: TranscriptEntry[]): Message[] {
+  return entries
+    .filter((e) => e.final && e.role !== 'unknown' && e.transcript.trim())
+    .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+    .map((e) => ({ role: e.role, content: e.transcript, timestamp: e.timestamp }));
+}

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -1,0 +1,40 @@
+// @consuelo/analytics — types
+
+export interface AnalyticsConfig {
+  storage?: "mongodb" | "sqlite" | "memory";
+  connectionString?: string;
+}
+
+export interface CallAnalytics {
+  callSid: string;
+  duration: number;
+  sentiment: SentimentAnalysis;
+  keyMoments: KeyMoment[];
+  performance: PerformanceMetrics;
+}
+
+export interface SentimentAnalysis {
+  overall: "positive" | "neutral" | "negative";
+  trajectory: Array<{ timestamp: string; score: number }>;
+}
+
+export interface KeyMoment {
+  timestamp: string;
+  type: string;
+  text: string;
+  significance: number;
+}
+
+export interface PerformanceMetrics {
+  talkRatio: number;
+  questionsAsked: number;
+  objectionsHandled: number;
+  closingAttempts: number;
+  avgResponseTime: number;
+}
+
+export interface TranscriptEntry {
+  speaker: "agent" | "customer";
+  text: string;
+  timestamp: string;
+}

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -1,40 +1,61 @@
-// @consuelo/analytics — types
-
+/** Configuration for the Analytics module */
 export interface AnalyticsConfig {
-  storage?: "mongodb" | "sqlite" | "memory";
-  connectionString?: string;
+  /** LLM API key (Groq or OpenAI) */
+  apiKey?: string;
+  /** Model to use for analytics generation */
+  model?: string;
+  /** Provider: 'groq' (default) or 'openai' */
+  provider?: 'groq' | 'openai';
 }
 
-export interface CallAnalytics {
-  callSid: string;
-  duration: number;
-  sentiment: SentimentAnalysis;
-  keyMoments: KeyMoment[];
-  performance: PerformanceMetrics;
+/** A single message in a conversation */
+export interface Message {
+  role: string;
+  content: string;
+  timestamp?: string;
 }
 
-export interface SentimentAnalysis {
-  overall: "positive" | "neutral" | "negative";
-  trajectory: Array<{ timestamp: string; score: number }>;
-}
-
-export interface KeyMoment {
-  timestamp: string;
-  type: string;
-  text: string;
-  significance: number;
-}
-
-export interface PerformanceMetrics {
-  talkRatio: number;
-  questionsAsked: number;
-  objectionsHandled: number;
-  closingAttempts: number;
-  avgResponseTime: number;
-}
-
+/** A raw transcription entry from a webhook */
 export interface TranscriptEntry {
-  speaker: "agent" | "customer";
-  text: string;
+  id: string;
+  callSid: string;
+  track: string;
+  transcript: string;
+  final: boolean;
+  stability?: string;
   timestamp: string;
+  role: 'sales_rep' | 'customer' | 'unknown';
+}
+
+/** Options for analyzeCall() */
+export interface AnalyzeCallOptions {
+  callSid?: string;
+  userId?: string;
+  phoneNumber?: string;
+  callDate?: string;
+}
+
+/** Options for getMetrics() */
+export interface MetricsQuery {
+  userId: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+/** Aggregate metrics result */
+export interface AggregateMetrics {
+  totalCalls: number;
+  avgScore: number;
+  avgTalkRatio: number;
+  totalQuestionsAsked: number;
+  totalObjectionsHandled: number;
+  callsWithNextSteps: number;
+}
+
+/** Storage interface — users supply their own persistence */
+export interface AnalyticsStore {
+  saveTranscript(callSid: string, entry: TranscriptEntry): Promise<void>;
+  getTranscript(callSid: string): Promise<TranscriptEntry[]>;
+  saveAnalytics(callSid: string, analytics: import('./schemas/models.js').CallAnalytics): Promise<void>;
+  getAnalytics(query: MetricsQuery): Promise<import('./schemas/models.js').CallAnalytics[]>;
 }

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@consuelo/api",
+  "version": "0.0.1",
+  "description": "Unified REST API layer for all Consuelo SDK modules",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,16 @@
-// @consuelo/api
-// Unified REST API layer for all Consuelo SDK modules
+// Middleware
+export { authMiddleware, rateLimitMiddleware, errorHandler } from './middleware/index.js';
 
-export {};
+// Routes
+export {
+  allRoutes,
+  callRoutes,
+  coachingRoutes,
+  contactRoutes,
+  analyticsRoutes,
+  webhookRoutes,
+} from './routes/index.js';
+export type { RouteDefinition } from './routes/index.js';
+
+// Types
+export type { ApiConfig, ApiKeyContext, ApiError, ApiRequest, ApiResponse } from './types.js';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,4 @@
+// @consuelo/api
+// Unified REST API layer for all Consuelo SDK modules
+
+export {};

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,0 +1,34 @@
+import type { ApiKeyContext, ApiRequest, ApiResponse } from '../types.js';
+
+/**
+ * API key authentication middleware.
+ * Expects `Authorization: Bearer sk_live_... | sk_test_...`
+ */
+export function authMiddleware(
+  validateKey?: (key: string) => Promise<ApiKeyContext | null>,
+) {
+  return async (req: ApiRequest, res: ApiResponse, next: () => void) => {
+    const header = req.headers['authorization'] ?? req.headers['Authorization'] ?? '';
+    const token = header.startsWith('Bearer ') ? header.slice(7) : '';
+
+    if (!token) {
+      res.status(401).json({ error: { code: 'unauthorized', message: 'Missing API key' } });
+      return;
+    }
+
+    if (validateKey) {
+      const ctx = await validateKey(token);
+      if (!ctx) {
+        res.status(401).json({ error: { code: 'unauthorized', message: 'Invalid API key' } });
+        return;
+      }
+      (req as any).apiKeyContext = ctx;
+    } else {
+      // Default: parse mode from key prefix
+      const mode = token.startsWith('sk_test_') ? 'test' : 'live';
+      (req as any).apiKeyContext = { userId: 'default', mode } satisfies ApiKeyContext;
+    }
+
+    next();
+  };
+}

--- a/packages/api/src/middleware/error-handler.ts
+++ b/packages/api/src/middleware/error-handler.ts
@@ -1,0 +1,15 @@
+import type { ApiRequest, ApiResponse } from '../types.js';
+
+/** Wraps a handler to catch errors and return consistent error format */
+export function errorHandler(handler: (req: ApiRequest, res: ApiResponse) => Promise<void>) {
+  return async (req: ApiRequest, res: ApiResponse) => {
+    try {
+      await handler(req, res);
+    } catch (err: any) {
+      const message = err?.message ?? 'Internal server error';
+      const code = err?.code ?? 'internal_error';
+      const status = err?.status ?? 500;
+      res.status(status).json({ error: { code, message } });
+    }
+  };
+}

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -1,0 +1,3 @@
+export { authMiddleware } from './auth.js';
+export { rateLimitMiddleware } from './rate-limit.js';
+export { errorHandler } from './error-handler.js';

--- a/packages/api/src/middleware/rate-limit.ts
+++ b/packages/api/src/middleware/rate-limit.ts
@@ -1,0 +1,28 @@
+import type { ApiRequest, ApiResponse } from '../types.js';
+
+/**
+ * Simple in-memory rate limiter.
+ */
+export function rateLimitMiddleware(max = 100, windowMs = 60_000) {
+  const hits = new Map<string, { count: number; resetAt: number }>();
+
+  return (req: ApiRequest, res: ApiResponse, next: () => void) => {
+    const key = req.headers['authorization'] ?? req.headers['x-forwarded-for'] ?? 'anon';
+    const now = Date.now();
+    const entry = hits.get(key);
+
+    if (!entry || now > entry.resetAt) {
+      hits.set(key, { count: 1, resetAt: now + windowMs });
+      next();
+      return;
+    }
+
+    if (entry.count >= max) {
+      res.status(429).json({ error: { code: 'rate_limited', message: 'Too many requests' } });
+      return;
+    }
+
+    entry.count++;
+    next();
+  };
+}

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -1,0 +1,104 @@
+import type { ApiRequest, ApiResponse } from '../types.js';
+
+/** Route descriptor — framework-agnostic */
+export interface RouteDefinition {
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  path: string;
+  handler: (req: ApiRequest, res: ApiResponse) => Promise<void>;
+}
+
+/** /v1/calls routes */
+export function callRoutes(): RouteDefinition[] {
+  return [
+    { method: 'POST', path: '/v1/calls', handler: async (req, res) => {
+      const body = req.body as any;
+      res.status(200).json({ callSid: body?.to ? `CA_${Date.now()}` : null, status: 'initiated' });
+    }},
+    { method: 'GET', path: '/v1/calls/:id', handler: async (req, res) => {
+      res.status(200).json({ callSid: req.params?.id, status: 'in-progress' });
+    }},
+    { method: 'POST', path: '/v1/calls/:id/hangup', handler: async (req, res) => {
+      res.status(200).json({ callSid: req.params?.id, status: 'completed' });
+    }},
+  ];
+}
+
+/** /v1/coaching routes */
+export function coachingRoutes(): RouteDefinition[] {
+  return [
+    { method: 'POST', path: '/v1/coaching', handler: async (req, res) => {
+      res.status(200).json({ message: 'Use @consuelo/coaching for full implementation' });
+    }},
+    { method: 'POST', path: '/v1/coaching/analyze', handler: async (req, res) => {
+      res.status(200).json({ message: 'Use @consuelo/coaching for full implementation' });
+    }},
+    { method: 'POST', path: '/v1/coaching/playbook', handler: async (req, res) => {
+      res.status(200).json({ message: 'Use @consuelo/coaching for full implementation' });
+    }},
+  ];
+}
+
+/** /v1/contacts routes */
+export function contactRoutes(): RouteDefinition[] {
+  return [
+    { method: 'GET', path: '/v1/contacts', handler: async (_req, res) => {
+      res.status(200).json({ contacts: [] });
+    }},
+    { method: 'POST', path: '/v1/contacts', handler: async (req, res) => {
+      res.status(201).json({ contact: req.body });
+    }},
+    { method: 'GET', path: '/v1/contacts/:id', handler: async (req, res) => {
+      res.status(200).json({ contact: { id: req.params?.id } });
+    }},
+    { method: 'PUT', path: '/v1/contacts/:id', handler: async (req, res) => {
+      res.status(200).json({ contact: { id: req.params?.id, ...req.body as any } });
+    }},
+    { method: 'DELETE', path: '/v1/contacts/:id', handler: async (req, res) => {
+      res.status(200).json({ deleted: true });
+    }},
+    { method: 'GET', path: '/v1/contacts/search', handler: async (_req, res) => {
+      res.status(200).json({ contacts: [] });
+    }},
+    { method: 'POST', path: '/v1/contacts/import', handler: async (_req, res) => {
+      res.status(200).json({ imported: 0 });
+    }},
+  ];
+}
+
+/** /v1/analytics routes */
+export function analyticsRoutes(): RouteDefinition[] {
+  return [
+    { method: 'POST', path: '/v1/analytics/analyze', handler: async (req, res) => {
+      res.status(200).json({ message: 'Use @consuelo/analytics for full implementation' });
+    }},
+    { method: 'GET', path: '/v1/analytics/transcript/:callSid', handler: async (req, res) => {
+      res.status(200).json({ callSid: req.params?.callSid, transcript: [] });
+    }},
+    { method: 'GET', path: '/v1/analytics/metrics', handler: async (_req, res) => {
+      res.status(200).json({ metrics: {} });
+    }},
+  ];
+}
+
+/** /v1/webhooks routes (Twilio callbacks) */
+export function webhookRoutes(): RouteDefinition[] {
+  return [
+    { method: 'POST', path: '/v1/webhooks/transcription', handler: async (_req, res) => {
+      res.status(200).json({ received: true });
+    }},
+    { method: 'POST', path: '/v1/webhooks/status', handler: async (_req, res) => {
+      res.status(200).json({ received: true });
+    }},
+  ];
+}
+
+/** All v1 routes combined */
+export function allRoutes(): RouteDefinition[] {
+  return [
+    ...callRoutes(),
+    ...coachingRoutes(),
+    ...contactRoutes(),
+    ...analyticsRoutes(),
+    ...webhookRoutes(),
+  ];
+}

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,0 +1,36 @@
+/** API configuration */
+export interface ApiConfig {
+  /** Function to validate an API key. Return user context or null. */
+  validateKey?: (key: string) => Promise<ApiKeyContext | null>;
+  /** Rate limit: max requests per window */
+  rateLimit?: { max: number; windowMs: number };
+}
+
+/** Context attached to an authenticated request */
+export interface ApiKeyContext {
+  userId: string;
+  orgId?: string;
+  mode: 'live' | 'test';
+  tier?: string;
+}
+
+/** Standard API error response */
+export interface ApiError {
+  error: { code: string; message: string };
+}
+
+/** Generic request abstraction */
+export interface ApiRequest {
+  method: string;
+  path: string;
+  headers: Record<string, string | undefined>;
+  body?: unknown;
+  query?: Record<string, string>;
+  params?: Record<string, string>;
+}
+
+/** Generic response helpers */
+export interface ApiResponse {
+  status(code: number): ApiResponse;
+  json(data: unknown): void;
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@consuelo/cli",
+  "version": "0.0.1",
+  "description": "CLI tool for Consuelo SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "consuelo": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@consuelo/dialer": "workspace:*",
+    "@consuelo/coaching": "workspace:*",
+    "@consuelo/analytics": "workspace:*",
+    "@consuelo/contacts": "workspace:*"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,10 +14,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@consuelo/dialer": "workspace:*",
-    "@consuelo/coaching": "workspace:*",
-    "@consuelo/analytics": "workspace:*",
-    "@consuelo/contacts": "workspace:*"
+    "@consuelo/dialer": "*",
+    "@consuelo/coaching": "*",
+    "@consuelo/analytics": "*",
+    "@consuelo/contacts": "*"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/cli/src/commands/analytics.ts
+++ b/packages/cli/src/commands/analytics.ts
@@ -1,0 +1,10 @@
+import { log, json, isJson } from '../output.js';
+
+export async function analyticsCommand(callSid: string): Promise<void> {
+  if (isJson()) {
+    json({ callSid, status: 'pending' });
+  } else {
+    log(`fetching analytics for ${callSid}...`);
+    log('(connect your analytics provider to generate real analytics)');
+  }
+}

--- a/packages/cli/src/commands/call.ts
+++ b/packages/cli/src/commands/call.ts
@@ -1,0 +1,16 @@
+import { loadConfig } from '../config.js';
+import { log, error, json, isJson } from '../output.js';
+
+export async function callCommand(number: string): Promise<void> {
+  const config = loadConfig();
+  if (!config.twilioAccountSid && !config.managed) {
+    error('not configured — run `consuelo init` first');
+    process.exit(1);
+  }
+  if (isJson()) {
+    json({ action: 'call', to: number, status: 'initiated' });
+  } else {
+    log(`calling ${number}...`);
+    log('(connect your dialer implementation to make real calls)');
+  }
+}

--- a/packages/cli/src/commands/coach.ts
+++ b/packages/cli/src/commands/coach.ts
@@ -1,0 +1,22 @@
+import * as fs from 'node:fs';
+import { log, error, json, isJson } from '../output.js';
+
+export async function coachCommand(opts: { transcript?: string }): Promise<void> {
+  if (!opts.transcript) {
+    error('provide a transcript file: consuelo coach --transcript <file>');
+    process.exit(1);
+  }
+  if (!fs.existsSync(opts.transcript)) {
+    error(`file not found: ${opts.transcript}`);
+    process.exit(1);
+  }
+  const content = fs.readFileSync(opts.transcript, 'utf-8');
+  const lines = content.trim().split('\n').filter(Boolean);
+
+  if (isJson()) {
+    json({ action: 'coach', lines: lines.length, status: 'ready' });
+  } else {
+    log(`loaded ${lines.length} lines from ${opts.transcript}`);
+    log('(connect your coaching provider to generate coaching tips)');
+  }
+}

--- a/packages/cli/src/commands/contacts.ts
+++ b/packages/cli/src/commands/contacts.ts
@@ -1,0 +1,25 @@
+import { log, json, isJson } from '../output.js';
+
+export async function contactsCommand(action: string, args: string[]): Promise<void> {
+  switch (action) {
+    case 'list':
+      if (isJson()) json({ contacts: [] });
+      else log('no contacts yet — use `consuelo contacts add` or `consuelo contacts import`');
+      break;
+    case 'add': {
+      const name = args[0] ?? 'Unknown';
+      const phone = args[1] ?? '';
+      if (isJson()) json({ action: 'add', name, phone });
+      else log(`added contact: ${name} ${phone}`);
+      break;
+    }
+    case 'import': {
+      const file = args[0];
+      if (isJson()) json({ action: 'import', file });
+      else log(`importing from ${file ?? '(no file)'}...`);
+      break;
+    }
+    default:
+      log('usage: consuelo contacts <list|add|import>');
+  }
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,34 @@
+import * as readline from 'node:readline';
+import { saveConfig } from '../config.js';
+import { log } from '../output.js';
+import type { CliConfig } from '../config.js';
+
+function ask(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => rl.question(question, resolve));
+}
+
+export async function initCommand(opts: { managed?: boolean }): Promise<void> {
+  if (opts.managed) {
+    saveConfig({ managed: true });
+    log('configured for managed mode — no credentials needed');
+    return;
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const config: CliConfig = {};
+
+  log('consuelo init — interactive setup\n');
+
+  config.twilioAccountSid = await ask(rl, 'twilio account sid: ');
+  config.twilioAuthToken = await ask(rl, 'twilio auth token: ');
+  config.twilioPhoneNumber = await ask(rl, 'twilio phone number (E.164): ');
+
+  const provider = await ask(rl, 'llm provider (groq/openai) [groq]: ');
+  config.llmProvider = provider === 'openai' ? 'openai' : 'groq';
+  config.llmApiKey = await ask(rl, `${config.llmProvider} api key: `);
+
+  rl.close();
+
+  saveConfig(config);
+  log('\nconfig saved to ~/.consuelo/config.json');
+}

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,19 @@
+import { loadConfig } from '../config.js';
+import { log, json, isJson } from '../output.js';
+
+export async function statusCommand(): Promise<void> {
+  const config = loadConfig();
+  if (isJson()) {
+    json({ configured: !!config.twilioAccountSid || !!config.managed, config });
+  } else {
+    if (config.managed) {
+      log('mode: managed');
+    } else if (config.twilioAccountSid) {
+      log(`twilio: ${config.twilioAccountSid}`);
+      log(`llm: ${config.llmProvider ?? 'groq'}`);
+      log(`phone: ${config.twilioPhoneNumber ?? '(not set)'}`);
+    } else {
+      log('not configured — run `consuelo init`');
+    }
+  }
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,28 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const CONFIG_DIR = path.join(os.homedir(), '.consuelo');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
+
+export interface CliConfig {
+  twilioAccountSid?: string;
+  twilioAuthToken?: string;
+  twilioPhoneNumber?: string;
+  llmProvider?: 'groq' | 'openai';
+  llmApiKey?: string;
+  managed?: boolean;
+}
+
+export function loadConfig(): CliConfig {
+  try {
+    return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+export function saveConfig(config: CliConfig): void {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// @consuelo/cli
+// CLI tool for Consuelo SDK
+
+console.log("consuelo cli — not yet implemented");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,65 @@
 #!/usr/bin/env node
-// @consuelo/cli
-// CLI tool for Consuelo SDK
 
-console.log("consuelo cli — not yet implemented");
+import { initCommand } from './commands/init.js';
+import { callCommand } from './commands/call.js';
+import { coachCommand } from './commands/coach.js';
+import { contactsCommand } from './commands/contacts.js';
+import { analyticsCommand } from './commands/analytics.js';
+import { statusCommand } from './commands/status.js';
+
+const args = process.argv.slice(2);
+const flags = new Set(args.filter((a) => a.startsWith('--')));
+const positional = args.filter((a) => !a.startsWith('--'));
+
+if (flags.has('--json')) (globalThis as any).__consuelo_json = true;
+if (flags.has('--quiet')) (globalThis as any).__consuelo_quiet = true;
+
+const command = positional[0];
+
+async function main() {
+  switch (command) {
+    case 'init':
+      await initCommand({ managed: flags.has('--managed') });
+      break;
+    case 'call':
+      await callCommand(positional[1] ?? '');
+      break;
+    case 'coach':
+      await coachCommand({ transcript: flagValue('--transcript') });
+      break;
+    case 'contacts':
+      await contactsCommand(positional[1] ?? 'list', positional.slice(2));
+      break;
+    case 'analytics':
+      await analyticsCommand(positional[1] ?? '');
+      break;
+    case 'status':
+      await statusCommand();
+      break;
+    default:
+      console.log(`consuelo — AI-powered sales toolkit
+
+commands:
+  init                    interactive setup
+  call <number>           make a call with AI coaching
+  coach --transcript <f>  analyze a transcript
+  contacts <action>       manage contacts (list|add|import)
+  analytics <callSid>     get call analytics
+  status                  show config and account status
+
+flags:
+  --json                  machine-readable output
+  --quiet                 suppress output
+  --managed               use hosted infrastructure`);
+  }
+}
+
+function flagValue(flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+main().catch((err) => {
+  console.error(`error: ${err.message}`);
+  process.exit(1);
+});

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,17 @@
+/** Simple output helpers — no external deps */
+
+export function log(msg: string): void {
+  if (!(globalThis as any).__consuelo_quiet) console.log(msg);
+}
+
+export function error(msg: string): void {
+  console.error(`error: ${msg}`);
+}
+
+export function json(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+export function isJson(): boolean {
+  return !!(globalThis as any).__consuelo_json;
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/coaching/package.json
+++ b/packages/coaching/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@consuelo/coaching",
+  "version": "0.0.1",
+  "description": "Real-time AI sales coaching engine with provider abstraction",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/coaching/package.json
+++ b/packages/coaching/package.json
@@ -11,6 +11,14 @@
     "typecheck": "tsc --noEmit"
   },
   "license": "MIT",
+  "peerDependencies": {
+    "openai": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "openai": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/coaching/src/coach.ts
+++ b/packages/coaching/src/coach.ts
@@ -1,0 +1,57 @@
+import type { CoachingProvider } from './providers/base.js';
+import type { CoachingConfig, Message, CoachOptions, AnalyzeOptions } from './types.js';
+import type { SalesCoaching, CallAnalytics } from './schemas/coaching.js';
+import { GroqProvider } from './providers/groq.js';
+import { analyzeConversationDynamics } from './services/dynamics.js';
+
+/**
+ * Main Coach class — the public API for @consuelo/coaching.
+ *
+ * @example
+ * ```ts
+ * import { Coach } from '@consuelo/coaching';
+ *
+ * const coach = new Coach({ apiKey: '...' });
+ * const tips = await coach.coach(transcript, { contextChunks: ['...'] });
+ * ```
+ */
+export class Coach {
+  readonly provider: CoachingProvider;
+
+  constructor(config: CoachingConfig & { customProvider?: CoachingProvider } = {}) {
+    this.provider = config.customProvider ?? new GroqProvider(config);
+  }
+
+  /** Get real-time coaching suggestions for an active conversation */
+  async coach(conversation: Message[], options: CoachOptions = {}): Promise<SalesCoaching> {
+    const dynamics = analyzeConversationDynamics(conversation);
+    const recent = conversation.slice(-(options.maxRecentMessages ?? 15));
+    const convText = recent.map((m) => `${m.role.toUpperCase()}: ${m.content}`).join('\n');
+
+    const lastCustomerMsg = dynamics.customer_messages.at(-1) ?? '';
+
+    const contextBlock = options.contextChunks?.length
+      ? 'Product Context:\n' + options.contextChunks.join('\n\n') + '\n\n'
+      : '';
+
+    const prompt =
+      `You are providing real-time sales coaching. Be direct and actionable.\n\n` +
+      contextBlock +
+      `Recent Conversation:\n${convText}\n\n` +
+      `Customer's Last Statement: ${lastCustomerMsg}\n\n` +
+      `Respond with JSON: {"product_or_option_name": "emotional trigger", "details": ["1-3 bold actionable phrases"], "clarifying_questions": ["2-3 pain funnel questions"]}\n` +
+      `NO summaries. ONLY actionable content.`;
+
+    return this.provider.coach(prompt);
+  }
+
+  /** Generate post-call analytics */
+  async analyzeCall(conversation: Message[], options: AnalyzeOptions = {}): Promise<CallAnalytics> {
+    const transcript = conversation.map((m) => `${m.role.toUpperCase()}: ${m.content}`).join('\n');
+    return this.provider.analyze(transcript, {
+      callSid: options.callSid ?? '',
+      userId: options.userId ?? '',
+      phoneNumber: options.phoneNumber ?? '',
+    });
+  }
+}

--- a/packages/coaching/src/index.ts
+++ b/packages/coaching/src/index.ts
@@ -1,0 +1,11 @@
+// @consuelo/coaching
+// Real-time AI sales coaching engine with provider abstraction
+
+export type {
+  CoachingConfig,
+  CoachingRequest,
+  SalesCoaching,
+  CoachingProvider,
+  CallAnalysis,
+  KeyMoment,
+} from "./types";

--- a/packages/coaching/src/index.ts
+++ b/packages/coaching/src/index.ts
@@ -1,11 +1,33 @@
-// @consuelo/coaching
-// Real-time AI sales coaching engine with provider abstraction
+// Core
+export { Coach } from './coach.js';
 
+// Providers
+export { GroqProvider } from './providers/groq.js';
+export { OpenAIProvider } from './providers/openai.js';
+export type { CoachingProvider } from './providers/base.js';
+
+// Services
+export { PlaybookService, chunkText } from './services/playbook.js';
+export { analyzeConversationDynamics } from './services/dynamics.js';
+export type { ConversationDynamics } from './services/dynamics.js';
+
+// Schemas
+export type {
+  SalesCoaching,
+  CallAnalytics,
+  KeyMoment,
+  SentimentAnalysis,
+  PerformanceMetrics,
+} from './schemas/coaching.js';
+
+// Types
 export type {
   CoachingConfig,
-  CoachingRequest,
-  SalesCoaching,
-  CoachingProvider,
-  CallAnalysis,
-  KeyMoment,
-} from "./types";
+  Message,
+  CoachOptions,
+  AnalyzeOptions,
+  PlaybookUploadOptions,
+  VectorStore,
+  EmbedFn,
+  ReadFileFn,
+} from './types.js';

--- a/packages/coaching/src/providers/base.ts
+++ b/packages/coaching/src/providers/base.ts
@@ -1,0 +1,10 @@
+import type { SalesCoaching, CallAnalytics } from '../schemas/coaching.js';
+
+/** LLM provider interface for coaching */
+export interface CoachingProvider {
+  /** Generate structured coaching from a prompt */
+  coach(prompt: string): Promise<SalesCoaching>;
+
+  /** Generate call analytics from a transcript */
+  analyze(transcript: string, meta: { callSid: string; userId: string; phoneNumber: string }): Promise<CallAnalytics>;
+}

--- a/packages/coaching/src/providers/groq.ts
+++ b/packages/coaching/src/providers/groq.ts
@@ -1,0 +1,70 @@
+import type { CoachingProvider } from './base.js';
+import type { SalesCoaching, CallAnalytics } from '../schemas/coaching.js';
+import type { CoachingConfig } from '../types.js';
+
+/**
+ * Groq-backed coaching provider.
+ *
+ * Uses the OpenAI-compatible API at api.groq.com.
+ * Requires `openai` as a peer dependency.
+ */
+export class GroqProvider implements CoachingProvider {
+  private config: CoachingConfig;
+  private client: any;
+
+  constructor(config: CoachingConfig = {}) {
+    this.config = {
+      model: 'llama-3.3-70b-versatile',
+      temperature: 0.4,
+      maxTokens: 1000,
+      ...config,
+      baseUrl: config.baseUrl ?? 'https://api.groq.com/openai/v1',
+      apiKey: config.apiKey ?? process.env.GROQ_API_KEY,
+    };
+  }
+
+  private async getClient() {
+    if (!this.client) {
+      const { default: OpenAI } = await import('openai');
+      this.client = new OpenAI({ apiKey: this.config.apiKey, baseURL: this.config.baseUrl });
+    }
+    return this.client;
+  }
+
+  async coach(prompt: string): Promise<SalesCoaching> {
+    const client = await this.getClient();
+    const res = await client.chat.completions.create({
+      model: this.config.model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: this.config.temperature,
+      max_tokens: this.config.maxTokens,
+      response_format: { type: 'json_object' },
+    });
+    return JSON.parse(res.choices[0].message.content) as SalesCoaching;
+  }
+
+  async analyze(transcript: string, meta: { callSid: string; userId: string; phoneNumber: string }): Promise<CallAnalytics> {
+    const client = await this.getClient();
+    const prompt = buildAnalyticsPrompt(transcript);
+    const res = await client.chat.completions.create({
+      model: this.config.model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.3,
+      max_tokens: 1500,
+      response_format: { type: 'json_object' },
+    });
+    const data = JSON.parse(res.choices[0].message.content);
+    return { ...data, call_sid: meta.callSid, user_id: meta.userId, phone_number: meta.phoneNumber, generated_at: new Date().toISOString() };
+  }
+}
+
+function buildAnalyticsPrompt(transcript: string): string {
+  return `Analyze this sales call transcript and provide detailed analytics.
+
+CALL TRANSCRIPT:
+${transcript}
+
+Return a JSON object with: key_moments (array of {timestamp, type, description, transcript_snippet}), sentiment_analysis ({customer_sentiment, engagement_level, objections_raised, buying_signals}), performance_metrics ({talk_ratio, questions_asked, objections_handled, next_steps_established, call_duration_minutes}), overall_score (0-100), strengths (array), improvement_areas (array), action_items (array).
+
+Be specific and constructive. talk_ratio is a decimal 0-1 representing agent talk time.`;
+}

--- a/packages/coaching/src/providers/index.ts
+++ b/packages/coaching/src/providers/index.ts
@@ -1,0 +1,3 @@
+export type { CoachingProvider } from './base.js';
+export { GroqProvider } from './groq.js';
+export { OpenAIProvider } from './openai.js';

--- a/packages/coaching/src/providers/openai.ts
+++ b/packages/coaching/src/providers/openai.ts
@@ -1,0 +1,56 @@
+import type { CoachingProvider } from './base.js';
+import type { SalesCoaching, CallAnalytics } from '../schemas/coaching.js';
+import type { CoachingConfig } from '../types.js';
+
+/**
+ * OpenAI-backed coaching provider.
+ * Requires `openai` as a peer dependency.
+ */
+export class OpenAIProvider implements CoachingProvider {
+  private config: CoachingConfig;
+  private client: any;
+
+  constructor(config: CoachingConfig = {}) {
+    this.config = {
+      model: 'gpt-4o-mini',
+      temperature: 0.4,
+      maxTokens: 1000,
+      ...config,
+      apiKey: config.apiKey ?? process.env.OPENAI_API_KEY,
+    };
+  }
+
+  private async getClient() {
+    if (!this.client) {
+      const { default: OpenAI } = await import('openai');
+      this.client = new OpenAI({ apiKey: this.config.apiKey, baseURL: this.config.baseUrl });
+    }
+    return this.client;
+  }
+
+  async coach(prompt: string): Promise<SalesCoaching> {
+    const client = await this.getClient();
+    const res = await client.chat.completions.create({
+      model: this.config.model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: this.config.temperature,
+      max_tokens: this.config.maxTokens,
+      response_format: { type: 'json_object' },
+    });
+    return JSON.parse(res.choices[0].message.content) as SalesCoaching;
+  }
+
+  async analyze(transcript: string, meta: { callSid: string; userId: string; phoneNumber: string }): Promise<CallAnalytics> {
+    const client = await this.getClient();
+    const prompt = `Analyze this sales call transcript. Return JSON with: key_moments, sentiment_analysis, performance_metrics, overall_score, strengths, improvement_areas, action_items.\n\nTRANSCRIPT:\n${transcript}`;
+    const res = await client.chat.completions.create({
+      model: this.config.model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.3,
+      max_tokens: 1500,
+      response_format: { type: 'json_object' },
+    });
+    const data = JSON.parse(res.choices[0].message.content);
+    return { ...data, call_sid: meta.callSid, user_id: meta.userId, phone_number: meta.phoneNumber, generated_at: new Date().toISOString() };
+  }
+}

--- a/packages/coaching/src/schemas/coaching.ts
+++ b/packages/coaching/src/schemas/coaching.ts
@@ -1,0 +1,49 @@
+/** Structured sales coaching output — mirrors the monolith's SalesCoaching pydantic model */
+export interface SalesCoaching {
+  product_or_option_name: string;
+  details: string[];
+  clarifying_questions?: string[] | null;
+  timestamp?: string | null;
+  is_new_content?: boolean | null;
+}
+
+/** Key moment during a call */
+export interface KeyMoment {
+  timestamp: string;
+  type: 'objection' | 'buying_signal' | 'price_discussion' | 'next_steps' | 'closing_attempt';
+  description: string;
+  transcript_snippet: string;
+}
+
+/** Sentiment analysis of a call */
+export interface SentimentAnalysis {
+  customer_sentiment: 'positive' | 'neutral' | 'negative' | 'mixed';
+  engagement_level: 'high' | 'medium' | 'low';
+  objections_raised: string[];
+  buying_signals: string[];
+}
+
+/** Quantitative call performance metrics */
+export interface PerformanceMetrics {
+  talk_ratio: number;
+  questions_asked: number;
+  objections_handled: number;
+  next_steps_established: boolean;
+  call_duration_minutes: number;
+}
+
+/** Complete post-call analytics */
+export interface CallAnalytics {
+  call_sid: string;
+  user_id: string;
+  phone_number: string;
+  call_date: string;
+  key_moments: KeyMoment[];
+  sentiment_analysis: SentimentAnalysis;
+  performance_metrics: PerformanceMetrics;
+  overall_score: number;
+  strengths: string[];
+  improvement_areas: string[];
+  action_items: string[];
+  generated_at: string;
+}

--- a/packages/coaching/src/services/dynamics.ts
+++ b/packages/coaching/src/services/dynamics.ts
@@ -1,0 +1,31 @@
+import type { Message } from '../types.js';
+
+export interface ConversationDynamics {
+  customer_messages: string[];
+  rep_messages: string[];
+  latest_speaker: 'customer' | 'sales_rep' | null;
+  total_exchanges: number;
+}
+
+/** Analyze conversation to understand customer vs sales rep dynamics. */
+export function analyzeConversationDynamics(conversation: Message[]): ConversationDynamics {
+  if (!conversation.length) {
+    return { customer_messages: [], rep_messages: [], latest_speaker: null, total_exchanges: 0 };
+  }
+
+  const customer_messages: string[] = [];
+  const rep_messages: string[] = [];
+  let latest_speaker: ConversationDynamics['latest_speaker'] = null;
+
+  for (const msg of conversation) {
+    if (msg.role === 'customer') {
+      customer_messages.push(msg.content);
+      latest_speaker = 'customer';
+    } else {
+      rep_messages.push(msg.content);
+      latest_speaker = 'sales_rep';
+    }
+  }
+
+  return { customer_messages, rep_messages, latest_speaker, total_exchanges: conversation.length };
+}

--- a/packages/coaching/src/services/index.ts
+++ b/packages/coaching/src/services/index.ts
@@ -1,0 +1,3 @@
+export { analyzeConversationDynamics } from './dynamics.js';
+export type { ConversationDynamics } from './dynamics.js';
+export { PlaybookService, chunkText } from './playbook.js';

--- a/packages/coaching/src/services/playbook.ts
+++ b/packages/coaching/src/services/playbook.ts
@@ -1,0 +1,58 @@
+import type { VectorStore, EmbedFn, ReadFileFn, PlaybookUploadOptions } from '../types.js';
+
+/** Split text into word-based chunks (default 500 words, matching monolith). */
+export function chunkText(text: string, chunkSize = 500): string[] {
+  const words = text.split(/\s+/);
+  const chunks: string[] = [];
+  for (let i = 0; i < words.length; i += chunkSize) {
+    chunks.push(words.slice(i, i + chunkSize).join(' '));
+  }
+  return chunks;
+}
+
+/**
+ * Playbook service — upload documents and retrieve relevant context via vector search.
+ *
+ * Requires user-supplied `embedFn` and `vectorStore` to stay free of heavy dependencies
+ * (sentence-transformers, chromadb, etc.).
+ */
+export class PlaybookService {
+  constructor(
+    private vectorStore: VectorStore,
+    private embedFn: EmbedFn,
+    private readFileFn?: ReadFileFn,
+  ) {}
+
+  /** Upload a document: extract text → chunk → embed → store */
+  async upload(content: Buffer | string, ext: string, options: PlaybookUploadOptions): Promise<{ chunksIndexed: number }> {
+    let text: string;
+    if (typeof content === 'string') {
+      text = content;
+    } else if (this.readFileFn) {
+      text = await this.readFileFn(content, ext);
+    } else {
+      text = content.toString('utf-8');
+    }
+
+    const chunks = chunkText(text, options.chunkSize);
+    const embeddings = await Promise.all(chunks.map((c) => this.embedFn(c)));
+    const ts = Date.now();
+    const ids = chunks.map((_, i) => `${options.collectionName}_chunk_${i}_${ts}`);
+    const metadata = chunks.map(() => {
+      const m: Record<string, string> = {};
+      if (options.userId) m.user_id = options.userId;
+      if (options.fileTag) m.file_tag = options.fileTag;
+      return m;
+    });
+
+    await this.vectorStore.add(chunks, embeddings, ids, metadata);
+    return { chunksIndexed: chunks.length };
+  }
+
+  /** Retrieve relevant context chunks for a query */
+  async retrieveContext(query: string, topK = 3, userId?: string): Promise<string[]> {
+    const embedding = await this.embedFn(query);
+    const where = userId ? { user_id: userId } : undefined;
+    return this.vectorStore.query(embedding, topK, where);
+  }
+}

--- a/packages/coaching/src/types.ts
+++ b/packages/coaching/src/types.ts
@@ -1,42 +1,49 @@
-// @consuelo/coaching — types
-
+/** LLM provider configuration */
 export interface CoachingConfig {
-  provider?: "groq" | "openai" | "anthropic";
+  provider?: 'groq' | 'openai' | 'anthropic';
   apiKey?: string;
   model?: string;
-  playbookDir?: string;
+  baseUrl?: string;
+  temperature?: number;
+  maxTokens?: number;
 }
 
-export interface CoachingRequest {
-  transcript: string;
-  context?: string;
-  playbook?: string;
+/** A single message in a conversation */
+export interface Message {
+  role: 'customer' | 'sales_rep';
+  content: string;
 }
 
-export interface SalesCoaching {
-  emotionalTrigger: string;
-  actionablePhrases: string[];
-  painFunnelQuestions: string[];
-  objectionHandling?: string;
-  closingStrategy?: string;
+/** Options for real-time coaching */
+export interface CoachOptions {
+  callSid?: string;
+  contextChunks?: string[];
+  maxRecentMessages?: number;
 }
 
-export interface CoachingProvider {
-  coach(request: CoachingRequest): Promise<SalesCoaching>;
-  analyzeCall(transcript: string): Promise<CallAnalysis>;
+/** Options for post-call analysis */
+export interface AnalyzeOptions {
+  callSid?: string;
+  userId?: string;
+  phoneNumber?: string;
 }
 
-export interface CallAnalysis {
-  sentiment: "positive" | "neutral" | "negative";
-  keyMoments: KeyMoment[];
-  talkRatio: number;
-  questionsAsked: number;
-  objectionsHandled: number;
+/** Playbook upload options */
+export interface PlaybookUploadOptions {
+  collectionName: string;
+  userId?: string;
+  fileTag?: string;
+  chunkSize?: number;
 }
 
-export interface KeyMoment {
-  timestamp: string;
-  type: "objection" | "buying_signal" | "closing_attempt" | "pain_point";
-  text: string;
-  significance: number;
+/** Vector store abstraction for playbook search */
+export interface VectorStore {
+  add(documents: string[], embeddings: number[][], ids: string[], metadata?: Record<string, string>[]): Promise<void>;
+  query(embedding: number[], topK: number, where?: Record<string, string>): Promise<string[]>;
 }
+
+/** Embedding function abstraction */
+export type EmbedFn = (text: string) => Promise<number[]>;
+
+/** Text extraction function for file uploads */
+export type ReadFileFn = (content: Buffer, ext: string) => Promise<string>;

--- a/packages/coaching/src/types.ts
+++ b/packages/coaching/src/types.ts
@@ -1,0 +1,42 @@
+// @consuelo/coaching — types
+
+export interface CoachingConfig {
+  provider?: "groq" | "openai" | "anthropic";
+  apiKey?: string;
+  model?: string;
+  playbookDir?: string;
+}
+
+export interface CoachingRequest {
+  transcript: string;
+  context?: string;
+  playbook?: string;
+}
+
+export interface SalesCoaching {
+  emotionalTrigger: string;
+  actionablePhrases: string[];
+  painFunnelQuestions: string[];
+  objectionHandling?: string;
+  closingStrategy?: string;
+}
+
+export interface CoachingProvider {
+  coach(request: CoachingRequest): Promise<SalesCoaching>;
+  analyzeCall(transcript: string): Promise<CallAnalysis>;
+}
+
+export interface CallAnalysis {
+  sentiment: "positive" | "neutral" | "negative";
+  keyMoments: KeyMoment[];
+  talkRatio: number;
+  questionsAsked: number;
+  objectionsHandled: number;
+}
+
+export interface KeyMoment {
+  timestamp: string;
+  type: "objection" | "buying_signal" | "closing_attempt" | "pain_point";
+  text: string;
+  significance: number;
+}

--- a/packages/coaching/tsconfig.json
+++ b/packages/coaching/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/contacts/package.json
+++ b/packages/contacts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@consuelo/contacts",
+  "version": "0.0.1",
+  "description": "Contact CRUD, queue management, and CSV import",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/contacts/src/contacts.ts
+++ b/packages/contacts/src/contacts.ts
@@ -1,0 +1,57 @@
+import type { Contact, StorageProvider } from './types.js';
+import { normalizePhone, parseCsv } from './utils.js';
+import { MemoryProvider } from './providers/memory.js';
+
+/**
+ * Contacts — CRUD, search, and CSV import for sales contacts.
+ */
+export class Contacts {
+  readonly store: StorageProvider;
+
+  constructor(store?: StorageProvider) {
+    this.store = store ?? new MemoryProvider();
+  }
+
+  async create(data: Omit<Contact, 'id' | 'createdAt' | 'updatedAt'>): Promise<Contact> {
+    return this.store.createContact({ ...data, phone: normalizePhone(data.phone) });
+  }
+
+  async get(id: string): Promise<Contact | null> {
+    return this.store.getContact(id);
+  }
+
+  async update(id: string, data: Partial<Contact>): Promise<Contact | null> {
+    if (data.phone) data.phone = normalizePhone(data.phone);
+    return this.store.updateContact(id, data);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.store.deleteContact(id);
+  }
+
+  async search(query: string, userId?: string): Promise<Contact[]> {
+    return this.store.searchContacts(query, userId);
+  }
+
+  async list(userId: string): Promise<Contact[]> {
+    return this.store.listContacts(userId);
+  }
+
+  /** Bulk import contacts from a CSV string. Expects columns: name, phone, email, company */
+  async importCsv(csv: string, userId?: string): Promise<Contact[]> {
+    const rows = parseCsv(csv);
+    const results: Contact[] = [];
+    for (const row of rows) {
+      if (!row.phone && !row.name) continue;
+      const contact = await this.create({
+        name: row.name ?? '',
+        phone: row.phone ?? '',
+        email: row.email,
+        company: row.company,
+        userId,
+      });
+      results.push(contact);
+    }
+    return results;
+  }
+}

--- a/packages/contacts/src/index.ts
+++ b/packages/contacts/src/index.ts
@@ -1,9 +1,17 @@
-// @consuelo/contacts
-// Contact CRUD, queue management, and CSV import
+// Core
+export { Contacts } from './contacts.js';
+export { Queues } from './queues.js';
 
+// Providers
+export { MemoryProvider } from './providers/memory.js';
+
+// Utilities
+export { normalizePhone, parseCsv } from './utils.js';
+
+// Types
 export type {
-  ContactsConfig,
   Contact,
   Queue,
+  QueueResult,
   StorageProvider,
-} from "./types";
+} from './types.js';

--- a/packages/contacts/src/index.ts
+++ b/packages/contacts/src/index.ts
@@ -1,0 +1,9 @@
+// @consuelo/contacts
+// Contact CRUD, queue management, and CSV import
+
+export type {
+  ContactsConfig,
+  Contact,
+  Queue,
+  StorageProvider,
+} from "./types";

--- a/packages/contacts/src/providers/index.ts
+++ b/packages/contacts/src/providers/index.ts
@@ -1,0 +1,1 @@
+export { MemoryProvider } from './memory.js';

--- a/packages/contacts/src/providers/memory.ts
+++ b/packages/contacts/src/providers/memory.ts
@@ -1,0 +1,63 @@
+import type { Contact, Queue, QueueResult, StorageProvider } from '../types.js';
+
+/** In-memory storage provider — useful for testing and simple setups */
+export class MemoryProvider implements StorageProvider {
+  private contacts = new Map<string, Contact>();
+  private queues = new Map<string, Queue>();
+  private nextId = 1;
+
+  private id(): string { return String(this.nextId++); }
+
+  async createContact(data: Omit<Contact, 'id' | 'createdAt' | 'updatedAt'>): Promise<Contact> {
+    const now = new Date().toISOString();
+    const contact: Contact = { ...data, id: this.id(), createdAt: now, updatedAt: now };
+    this.contacts.set(contact.id, contact);
+    return contact;
+  }
+
+  async getContact(id: string): Promise<Contact | null> {
+    return this.contacts.get(id) ?? null;
+  }
+
+  async updateContact(id: string, data: Partial<Contact>): Promise<Contact | null> {
+    const existing = this.contacts.get(id);
+    if (!existing) return null;
+    const updated = { ...existing, ...data, id, updatedAt: new Date().toISOString() };
+    this.contacts.set(id, updated);
+    return updated;
+  }
+
+  async deleteContact(id: string): Promise<boolean> {
+    return this.contacts.delete(id);
+  }
+
+  async searchContacts(query: string, userId?: string): Promise<Contact[]> {
+    const q = query.toLowerCase();
+    return [...this.contacts.values()].filter((c) => {
+      if (userId && c.userId !== userId) return false;
+      return c.name?.toLowerCase().includes(q) || c.phone?.includes(q) || c.email?.toLowerCase().includes(q);
+    });
+  }
+
+  async listContacts(userId: string): Promise<Contact[]> {
+    return [...this.contacts.values()].filter((c) => c.userId === userId);
+  }
+
+  async createQueue(data: Omit<Queue, 'id' | 'createdAt'>): Promise<Queue> {
+    const queue: Queue = { ...data, id: this.id(), createdAt: new Date().toISOString() };
+    this.queues.set(queue.id, queue);
+    return queue;
+  }
+
+  async getQueue(id: string): Promise<Queue | null> {
+    return this.queues.get(id) ?? null;
+  }
+
+  async updateQueue(id: string, data: Partial<Queue>): Promise<Queue | null> {
+    const existing = this.queues.get(id);
+    if (!existing) return null;
+    const updated = { ...existing, ...data, id };
+    this.queues.set(id, updated);
+    return updated;
+  }
+}

--- a/packages/contacts/src/queues.ts
+++ b/packages/contacts/src/queues.ts
@@ -1,0 +1,49 @@
+import type { Queue, QueueResult, StorageProvider } from './types.js';
+import { MemoryProvider } from './providers/memory.js';
+
+/**
+ * Queues — call queue management with ordering and attempt tracking.
+ */
+export class Queues {
+  readonly store: StorageProvider;
+
+  constructor(store?: StorageProvider) {
+    this.store = store ?? new MemoryProvider();
+  }
+
+  async create(name: string, contactIds: string[], ordering: Queue['ordering'] = 'sequential'): Promise<Queue> {
+    return this.store.createQueue({ name, contactIds, ordering, currentIndex: 0, status: 'idle', results: [] });
+  }
+
+  /** Get the next contact ID in the queue, advancing the pointer */
+  async getNext(queueId: string): Promise<string | null> {
+    const queue = await this.store.getQueue(queueId);
+    if (!queue || queue.status === 'completed' || queue.currentIndex >= queue.contactIds.length) return null;
+
+    const contactId = queue.contactIds[queue.currentIndex];
+    await this.store.updateQueue(queueId, {
+      currentIndex: queue.currentIndex + 1,
+      status: queue.currentIndex + 1 >= queue.contactIds.length ? 'completed' : 'active',
+    });
+    return contactId;
+  }
+
+  /** Record a call attempt result */
+  async recordResult(queueId: string, result: QueueResult): Promise<void> {
+    const queue = await this.store.getQueue(queueId);
+    if (!queue) return;
+    await this.store.updateQueue(queueId, { results: [...queue.results, result] });
+  }
+
+  async get(queueId: string): Promise<Queue | null> {
+    return this.store.getQueue(queueId);
+  }
+
+  async pause(queueId: string): Promise<void> {
+    await this.store.updateQueue(queueId, { status: 'paused' });
+  }
+
+  async resume(queueId: string): Promise<void> {
+    await this.store.updateQueue(queueId, { status: 'active' });
+  }
+}

--- a/packages/contacts/src/types.ts
+++ b/packages/contacts/src/types.ts
@@ -1,0 +1,36 @@
+// @consuelo/contacts — types
+
+export interface ContactsConfig {
+  storage?: "mongodb" | "sqlite" | "memory";
+  connectionString?: string;
+}
+
+export interface Contact {
+  id: string;
+  firstName: string;
+  lastName: string;
+  phone: string; // E.164 format
+  email?: string;
+  company?: string;
+  tags?: string[];
+  customFields?: Record<string, string>;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Queue {
+  id: string;
+  name: string;
+  contacts: string[]; // contact IDs
+  ordering: "round-robin" | "priority" | "custom";
+  currentIndex: number;
+}
+
+export interface StorageProvider {
+  create(contact: Omit<Contact, "id" | "createdAt" | "updatedAt">): Promise<Contact>;
+  get(id: string): Promise<Contact | null>;
+  update(id: string, data: Partial<Contact>): Promise<Contact>;
+  delete(id: string): Promise<void>;
+  search(query: string): Promise<Contact[]>;
+  importCsv(csv: string): Promise<Contact[]>;
+}

--- a/packages/contacts/src/types.ts
+++ b/packages/contacts/src/types.ts
@@ -1,36 +1,49 @@
-// @consuelo/contacts — types
-
-export interface ContactsConfig {
-  storage?: "mongodb" | "sqlite" | "memory";
-  connectionString?: string;
-}
-
+/** Contact record */
 export interface Contact {
   id: string;
-  firstName: string;
-  lastName: string;
-  phone: string; // E.164 format
+  name: string;
+  phone: string; // E.164
   email?: string;
   company?: string;
   tags?: string[];
   customFields?: Record<string, string>;
-  createdAt: Date;
-  updatedAt: Date;
+  userId?: string;
+  orgId?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
+/** Queue record */
 export interface Queue {
   id: string;
   name: string;
-  contacts: string[]; // contact IDs
-  ordering: "round-robin" | "priority" | "custom";
+  contactIds: string[];
+  ordering: 'sequential' | 'round-robin' | 'priority';
   currentIndex: number;
+  status: 'idle' | 'active' | 'paused' | 'completed';
+  results: QueueResult[];
+  createdAt: string;
 }
 
+export interface QueueResult {
+  contactId: string;
+  callSid?: string;
+  outcome?: string;
+  attemptedAt: string;
+}
+
+/** Storage provider interface — users supply their own persistence */
 export interface StorageProvider {
-  create(contact: Omit<Contact, "id" | "createdAt" | "updatedAt">): Promise<Contact>;
-  get(id: string): Promise<Contact | null>;
-  update(id: string, data: Partial<Contact>): Promise<Contact>;
-  delete(id: string): Promise<void>;
-  search(query: string): Promise<Contact[]>;
-  importCsv(csv: string): Promise<Contact[]>;
+  // Contacts
+  createContact(contact: Omit<Contact, 'id' | 'createdAt' | 'updatedAt'>): Promise<Contact>;
+  getContact(id: string): Promise<Contact | null>;
+  updateContact(id: string, data: Partial<Contact>): Promise<Contact | null>;
+  deleteContact(id: string): Promise<boolean>;
+  searchContacts(query: string, userId?: string): Promise<Contact[]>;
+  listContacts(userId: string): Promise<Contact[]>;
+
+  // Queues
+  createQueue(queue: Omit<Queue, 'id' | 'createdAt'>): Promise<Queue>;
+  getQueue(id: string): Promise<Queue | null>;
+  updateQueue(id: string, data: Partial<Queue>): Promise<Queue | null>;
 }

--- a/packages/contacts/src/utils.ts
+++ b/packages/contacts/src/utils.ts
@@ -1,0 +1,21 @@
+/** Normalize a phone number to E.164 format */
+export function normalizePhone(phone: string): string {
+  if (!phone) return '';
+  const digits = phone.replace(/\D/g, '');
+  if (digits.length === 11 && digits.startsWith('1')) return `+${digits}`;
+  if (digits.length === 10) return `+1${digits}`;
+  return `+${digits}`;
+}
+
+/** Parse a CSV string into an array of record objects */
+export function parseCsv(csv: string): Record<string, string>[] {
+  const lines = csv.trim().split('\n');
+  if (lines.length < 2) return [];
+  const headers = lines[0].split(',').map((h) => h.trim().toLowerCase());
+  return lines.slice(1).map((line) => {
+    const values = line.split(',').map((v) => v.trim());
+    const record: Record<string, string> = {};
+    headers.forEach((h, i) => { record[h] = values[i] ?? ''; });
+    return record;
+  });
+}

--- a/packages/contacts/tsconfig.json
+++ b/packages/contacts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/dialer/package.json
+++ b/packages/dialer/package.json
@@ -11,6 +11,14 @@
     "typecheck": "tsc --noEmit"
   },
   "license": "MIT",
+  "peerDependencies": {
+    "twilio": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "twilio": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/dialer/package.json
+++ b/packages/dialer/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@consuelo/dialer",
+  "version": "0.0.1",
+  "description": "Twilio-powered dialer with local presence and caller ID",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dialer/src/dialer.ts
+++ b/packages/dialer/src/dialer.ts
@@ -1,0 +1,124 @@
+import type { DialerProvider } from './providers/base.js';
+import type {
+  DialerConfig,
+  DialOptions,
+  DialResult,
+  HangupResult,
+  VoiceToken,
+  ProvisionNumberOptions,
+  ProvisionResult,
+} from './types.js';
+import { TwilioProvider } from './providers/twilio.js';
+import { LocalPresenceService } from './services/local-presence.js';
+import type { NumberPool } from './services/local-presence.js';
+import { CallerIdLockService } from './services/caller-id.js';
+
+/**
+ * Main Dialer class — the public API for @consuelo/dialer.
+ *
+ * Composes a telephony provider with local presence and caller ID
+ * locking services to provide a clean, high-level dialing interface.
+ *
+ * @example
+ * ```ts
+ * import { Dialer } from '@consuelo/dialer';
+ *
+ * const dialer = new Dialer({ credentials: { accountSid: '...', authToken: '...' } });
+ * const result = await dialer.dial({ to: '+15551234567', from: '+15559876543', userId: 'user_1' });
+ * ```
+ */
+export class Dialer {
+  readonly provider: DialerProvider;
+  readonly localPresence: LocalPresenceService;
+  private callerIdLock?: CallerIdLockService;
+  private config: DialerConfig;
+
+  constructor(config: DialerConfig = {}) {
+    this.config = config;
+    this.provider = new TwilioProvider(config.credentials);
+    this.localPresence = new LocalPresenceService();
+  }
+
+  /** Attach a caller ID lock service (optional, for concurrent call protection) */
+  withCallerIdLock(service: CallerIdLockService): this {
+    this.callerIdLock = service;
+    return this;
+  }
+
+  /**
+   * Initiate an outbound call.
+   *
+   * Number selection priority:
+   *  1. options.callerIdNumber (manual override)
+   *  2. Local presence match (if localPresence enabled and numberPool provided)
+   *  3. config.defaultNumber
+   *  4. options.from (agent's personal number)
+   */
+  async dial(options: DialOptions, numberPool?: NumberPool): Promise<DialResult> {
+    let callerIdNumber = options.callerIdNumber;
+    let selectionMethod: DialResult['selectionMethod'] = 'manual';
+
+    // auto-select via local presence if no manual override
+    if (!callerIdNumber && options.localPresence !== false && numberPool) {
+      const selection = await this.localPresence.selectNumber(numberPool, options.to);
+      if (selection) {
+        callerIdNumber = selection.phoneNumber;
+        selectionMethod = selection.localMatch
+          ? 'local_presence'
+          : selection.proximityMatch
+            ? 'local_presence'
+            : 'primary_fallback';
+      }
+    }
+
+    if (!callerIdNumber && this.config.defaultNumber) {
+      callerIdNumber = this.config.defaultNumber;
+      selectionMethod = 'primary';
+    }
+
+    if (!callerIdNumber) {
+      selectionMethod = 'system_default';
+    }
+
+    // acquire caller ID lock if service is configured
+    if (callerIdNumber && this.callerIdLock) {
+      const locked = await this.callerIdLock.acquireLock(callerIdNumber, options.userId, '');
+      if (!locked) {
+        return { success: false, error: 'Caller ID number is currently in use by another call' };
+      }
+    }
+
+    const result = await this.provider.dial({
+      ...options,
+      callerIdNumber,
+      statusCallbackUrl: options.statusCallbackUrl ?? this.config.baseUrl,
+    });
+
+    // update lock with actual call SID
+    if (result.success && result.callSid && callerIdNumber && this.callerIdLock) {
+      await this.callerIdLock.releaseLock('');
+      await this.callerIdLock.acquireLock(callerIdNumber, options.userId, result.callSid);
+    }
+
+    return { ...result, selectionMethod };
+  }
+
+  /** Hang up an active call and release any caller ID lock */
+  async hangup(callSid: string): Promise<HangupResult> {
+    const result = await this.provider.hangup(callSid);
+    if (this.callerIdLock) {
+      await this.callerIdLock.releaseLock(callSid);
+    }
+    return result;
+  }
+
+  /** Generate a voice token for browser-based calling */
+  async getToken(userId: string): Promise<VoiceToken> {
+    return this.provider.getToken(userId);
+  }
+
+  /** Provision a new phone number */
+  async provisionNumber(options: ProvisionNumberOptions): Promise<ProvisionResult> {
+    return this.provider.provisionNumber(options);
+  }
+}

--- a/packages/dialer/src/index.ts
+++ b/packages/dialer/src/index.ts
@@ -1,9 +1,27 @@
-// @consuelo/dialer
-// Twilio-powered dialer with local presence and caller ID
+// Core
+export { Dialer } from './dialer.js';
 
+// Providers
+export { TwilioProvider } from './providers/twilio.js';
+export type { DialerProvider } from './providers/base.js';
+
+// Services
+export { LocalPresenceService, extractAreaCode } from './services/local-presence.js';
+export { CallerIdLockService, InMemoryLockStore } from './services/caller-id.js';
+export type { LockStore } from './services/caller-id.js';
+export type { NumberPool } from './services/local-presence.js';
+
+// Types
 export type {
+  TwilioCredentials,
   DialerConfig,
-  CallOptions,
-  CallResult,
-  DialerProvider,
-} from "./types";
+  DialOptions,
+  DialResult,
+  HangupResult,
+  VoiceToken,
+  ProvisionNumberOptions,
+  ProvisionResult,
+  PhoneNumber,
+  NumberSelection,
+  CallerIdLock,
+} from './types.js';

--- a/packages/dialer/src/index.ts
+++ b/packages/dialer/src/index.ts
@@ -1,0 +1,9 @@
+// @consuelo/dialer
+// Twilio-powered dialer with local presence and caller ID
+
+export type {
+  DialerConfig,
+  CallOptions,
+  CallResult,
+  DialerProvider,
+} from "./types";

--- a/packages/dialer/src/providers/base.ts
+++ b/packages/dialer/src/providers/base.ts
@@ -1,0 +1,31 @@
+import type {
+  DialOptions,
+  DialResult,
+  HangupResult,
+  VoiceToken,
+  ProvisionNumberOptions,
+  ProvisionResult,
+} from '../types.js';
+
+/**
+ * Abstract dialer provider interface.
+ * Implement this to add support for telephony providers beyond Twilio.
+ */
+export interface DialerProvider {
+  readonly name: string;
+
+  /** Initiate an outbound call */
+  dial(options: DialOptions): Promise<DialResult>;
+
+  /** Hang up an active call */
+  hangup(callSid: string): Promise<HangupResult>;
+
+  /** Generate a voice token for browser-based calling */
+  getToken(userId: string): Promise<VoiceToken>;
+
+  /** Provision a new phone number */
+  provisionNumber(options: ProvisionNumberOptions): Promise<ProvisionResult>;
+
+  /** Check if a call is in a terminal state */
+  isCallCompleted(callSid: string): Promise<boolean>;
+}

--- a/packages/dialer/src/providers/index.ts
+++ b/packages/dialer/src/providers/index.ts
@@ -1,0 +1,2 @@
+export type { DialerProvider } from './base.js';
+export { TwilioProvider } from './twilio.js';

--- a/packages/dialer/src/providers/twilio.ts
+++ b/packages/dialer/src/providers/twilio.ts
@@ -1,0 +1,162 @@
+import type { DialerProvider } from './base.js';
+import type {
+  TwilioCredentials,
+  DialOptions,
+  DialResult,
+  HangupResult,
+  VoiceToken,
+  ProvisionNumberOptions,
+  ProvisionResult,
+} from '../types.js';
+
+const TERMINAL_STATUSES = ['completed', 'failed', 'busy', 'no-answer', 'canceled'];
+
+/**
+ * Twilio implementation of the DialerProvider.
+ *
+ * Requires the `twilio` package as a peer dependency.
+ * Credentials can be passed directly or read from env vars:
+ *   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_API_KEY,
+ *   TWILIO_API_SECRET, TWILIO_TWIML_APP_SID
+ */
+export class TwilioProvider implements DialerProvider {
+  readonly name = 'twilio';
+  private client: any;
+  private credentials: TwilioCredentials;
+
+  constructor(credentials?: TwilioCredentials) {
+    this.credentials = {
+      accountSid: credentials?.accountSid ?? process.env.TWILIO_ACCOUNT_SID ?? '',
+      authToken: credentials?.authToken ?? process.env.TWILIO_AUTH_TOKEN ?? '',
+      apiKey: credentials?.apiKey ?? process.env.TWILIO_API_KEY,
+      apiSecret: credentials?.apiSecret ?? process.env.TWILIO_API_SECRET,
+      twimlAppSid: credentials?.twimlAppSid ?? process.env.TWILIO_TWIML_APP_SID,
+    };
+  }
+
+  private async getClient(): Promise<any> {
+    if (this.client) return this.client;
+    const twilio = await import('twilio');
+    this.client = twilio.default(this.credentials.accountSid, this.credentials.authToken);
+    return this.client;
+  }
+
+  async dial(options: DialOptions): Promise<DialResult> {
+    try {
+      const client = await this.getClient();
+      const fromNumber = options.callerIdNumber ?? options.from;
+
+      const call = await client.calls.create({
+        to: options.from, // call the agent first (3-way pattern)
+        from: fromNumber,
+        url: options.statusCallbackUrl
+          ? `${options.statusCallbackUrl}?customer_number=${encodeURIComponent(options.to)}&user_id=${encodeURIComponent(options.userId)}`
+          : undefined,
+        statusCallback: options.statusCallbackUrl,
+        statusCallbackEvent: ['completed'],
+        statusCallbackMethod: 'POST',
+      });
+
+      return {
+        success: true,
+        callSid: call.sid,
+        fromNumber,
+        selectionMethod: options.callerIdNumber ? 'manual' : 'system_default',
+      };
+    } catch (err: any) {
+      return { success: false, error: err.message };
+    }
+  }
+
+  async hangup(callSid: string): Promise<HangupResult> {
+    try {
+      const client = await this.getClient();
+      await client.calls(callSid).update({ status: 'completed' });
+      return { success: true, callSid };
+    } catch (err: any) {
+      return { success: false, callSid, error: err.message };
+    }
+  }
+
+  async getToken(userId: string): Promise<VoiceToken> {
+    const { apiKey, apiSecret, twimlAppSid, accountSid } = this.credentials;
+    if (!apiKey || !apiSecret || !twimlAppSid) {
+      throw new Error('Twilio API key, secret, and TwiML app SID are required for voice tokens');
+    }
+
+    const twilio = await import('twilio');
+    const { AccessToken } = twilio.jwt;
+    const { VoiceGrant } = AccessToken;
+
+    const identity = `user_${userId}`;
+    const ttl = 3600;
+
+    const token = new AccessToken(accountSid, apiKey, apiSecret, { identity, ttl });
+    const grant = new VoiceGrant({ outgoingApplicationSid: twimlAppSid, incomingAllow: true });
+    token.addGrant(grant);
+
+    return { token: token.toJwt(), identity, ttl };
+  }
+
+  async provisionNumber(options: ProvisionNumberOptions): Promise<ProvisionResult> {
+    try {
+      const client = await this.getClient();
+
+      if (options.phoneNumber) {
+        // provision a specific number
+        const number = await client.incomingPhoneNumbers.create({
+          phoneNumber: options.phoneNumber,
+          friendlyName: options.friendlyName ?? 'Consuelo Number',
+          voiceUrl: options.voiceUrl,
+          voiceMethod: 'POST',
+          smsUrl: options.smsUrl,
+          smsMethod: 'POST',
+        });
+        return {
+          success: true,
+          phoneNumber: number.phoneNumber,
+          sid: number.sid,
+          areaCode: options.areaCode,
+        };
+      }
+
+      // search by area code then provision first available
+      const available = await client.availablePhoneNumbers('US').local.list({
+        areaCode: options.areaCode,
+        limit: 1,
+      });
+
+      if (!available.length) {
+        return { success: false, error: `No numbers available for area code ${options.areaCode}` };
+      }
+
+      const number = await client.incomingPhoneNumbers.create({
+        phoneNumber: available[0].phoneNumber,
+        friendlyName: options.friendlyName ?? 'Consuelo Number',
+        voiceUrl: options.voiceUrl,
+        voiceMethod: 'POST',
+        smsUrl: options.smsUrl,
+        smsMethod: 'POST',
+      });
+
+      return {
+        success: true,
+        phoneNumber: number.phoneNumber,
+        sid: number.sid,
+        areaCode: options.areaCode,
+      };
+    } catch (err: any) {
+      return { success: false, error: err.message };
+    }
+  }
+
+  async isCallCompleted(callSid: string): Promise<boolean> {
+    try {
+      const client = await this.getClient();
+      const call = await client.calls(callSid).fetch();
+      return TERMINAL_STATUSES.includes(call.status);
+    } catch {
+      return true; // if we can't fetch it, treat as completed
+    }
+  }
+}

--- a/packages/dialer/src/services/caller-id.ts
+++ b/packages/dialer/src/services/caller-id.ts
@@ -1,0 +1,109 @@
+import type { CallerIdLock } from '../types.js';
+
+/**
+ * Caller ID lock service — prevents concurrent use of the same
+ * outbound number across multiple active calls.
+ *
+ * This is a storage-agnostic interface. Provide your own store
+ * implementation (e.g. MongoDB, Redis, in-memory for testing).
+ */
+export interface LockStore {
+  acquire(lock: CallerIdLock): Promise<boolean>;
+  release(callSid: string): Promise<boolean>;
+  releaseByNumber(phoneNumber: string): Promise<boolean>;
+  isAvailable(phoneNumber: string): Promise<boolean>;
+  getByCallSid(callSid: string): Promise<CallerIdLock | null>;
+  getByUser(userId: string): Promise<CallerIdLock[]>;
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export class CallerIdLockService {
+  private store: LockStore;
+  private ttlMs: number;
+
+  constructor(store: LockStore, ttlMs?: number) {
+    this.store = store;
+    this.ttlMs = ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  async acquireLock(phoneNumber: string, userId: string, callSid: string): Promise<boolean> {
+    const now = new Date();
+    return this.store.acquire({
+      phoneNumber,
+      userId,
+      callSid,
+      acquiredAt: now,
+      expiresAt: new Date(now.getTime() + this.ttlMs),
+    });
+  }
+
+  async releaseLock(callSid: string): Promise<boolean> {
+    return this.store.release(callSid);
+  }
+
+  async releaseLockByNumber(phoneNumber: string): Promise<boolean> {
+    return this.store.releaseByNumber(phoneNumber);
+  }
+
+  async isNumberAvailable(phoneNumber: string): Promise<boolean> {
+    return this.store.isAvailable(phoneNumber);
+  }
+
+  async getUserLocks(userId: string): Promise<CallerIdLock[]> {
+    return this.store.getByUser(userId);
+  }
+}
+
+/**
+ * Simple in-memory lock store for testing / single-process use.
+ */
+export class InMemoryLockStore implements LockStore {
+  private locks = new Map<string, CallerIdLock>();
+
+  async acquire(lock: CallerIdLock): Promise<boolean> {
+    // clean expired
+    this.cleanExpired();
+    const existing = this.locks.get(lock.phoneNumber);
+    if (existing && existing.callSid !== lock.callSid) return false;
+    this.locks.set(lock.phoneNumber, lock);
+    return true;
+  }
+
+  async release(callSid: string): Promise<boolean> {
+    for (const [key, lock] of this.locks) {
+      if (lock.callSid === callSid) {
+        this.locks.delete(key);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  async releaseByNumber(phoneNumber: string): Promise<boolean> {
+    return this.locks.delete(phoneNumber);
+  }
+
+  async isAvailable(phoneNumber: string): Promise<boolean> {
+    this.cleanExpired();
+    return !this.locks.has(phoneNumber);
+  }
+
+  async getByCallSid(callSid: string): Promise<CallerIdLock | null> {
+    for (const lock of this.locks.values()) {
+      if (lock.callSid === callSid) return lock;
+    }
+    return null;
+  }
+
+  async getByUser(userId: string): Promise<CallerIdLock[]> {
+    return [...this.locks.values()].filter((l) => l.userId === userId);
+  }
+
+  private cleanExpired(): void {
+    const now = Date.now();
+    for (const [key, lock] of this.locks) {
+      if (lock.expiresAt.getTime() < now) this.locks.delete(key);
+    }
+  }
+}

--- a/packages/dialer/src/services/index.ts
+++ b/packages/dialer/src/services/index.ts
@@ -1,0 +1,4 @@
+export { LocalPresenceService, extractAreaCode } from './local-presence.js';
+export type { NumberPool } from './local-presence.js';
+export { CallerIdLockService, InMemoryLockStore } from './caller-id.js';
+export type { LockStore } from './caller-id.js';

--- a/packages/dialer/src/services/local-presence.ts
+++ b/packages/dialer/src/services/local-presence.ts
@@ -1,0 +1,101 @@
+import type { PhoneNumber, NumberSelection } from '../types.js';
+
+/**
+ * Extracts the 3-digit US area code from an E.164 number (+1XXXXXXXXXX).
+ */
+export function extractAreaCode(phoneNumber: string): string | null {
+  const cleaned = phoneNumber.replace(/\D/g, '');
+  if (cleaned.length === 11 && cleaned.startsWith('1')) return cleaned.slice(1, 4);
+  if (cleaned.length === 10) return cleaned.slice(0, 3);
+  return null;
+}
+
+export interface NumberPool {
+  numbers: PhoneNumber[];
+  primaryNumber?: PhoneNumber;
+}
+
+/**
+ * Local presence service — selects the best outbound number
+ * based on geographic proximity to the customer's area code.
+ *
+ * Selection priority:
+ *  1. Exact area code match
+ *  2. Closest area code within maxDistanceMiles (requires distanceFn)
+ *  3. Primary number fallback
+ */
+export class LocalPresenceService {
+  private maxDistanceMiles: number;
+  private distanceFn?: (areaCodeA: string, areaCodeB: string) => Promise<number | null>;
+
+  constructor(opts?: {
+    maxDistanceMiles?: number;
+    distanceFn?: (a: string, b: string) => Promise<number | null>;
+  }) {
+    this.maxDistanceMiles = opts?.maxDistanceMiles ?? 100;
+    this.distanceFn = opts?.distanceFn;
+  }
+
+  async selectNumber(pool: NumberPool, customerNumber: string): Promise<NumberSelection | null> {
+    const customerAreaCode = extractAreaCode(customerNumber);
+    if (!customerAreaCode || !pool.numbers.length) {
+      return this.primaryFallback(pool, customerAreaCode);
+    }
+
+    // 1. exact area code match
+    const exact = pool.numbers.find((n) => n.areaCode === customerAreaCode && n.isActive);
+    if (exact) {
+      return {
+        phoneNumber: exact.phoneNumber,
+        areaCode: exact.areaCode,
+        localMatch: true,
+        proximityMatch: false,
+        isPrimary: exact.isPrimary,
+        customerAreaCode,
+      };
+    }
+
+    // 2. proximity match (if distance function provided)
+    if (this.distanceFn) {
+      let best: { number: PhoneNumber; distance: number } | null = null;
+
+      for (const num of pool.numbers) {
+        if (!num.isActive) continue;
+        const dist = await this.distanceFn(customerAreaCode, num.areaCode);
+        if (dist !== null && dist <= this.maxDistanceMiles) {
+          if (!best || dist < best.distance) {
+            best = { number: num, distance: dist };
+          }
+        }
+      }
+
+      if (best) {
+        return {
+          phoneNumber: best.number.phoneNumber,
+          areaCode: best.number.areaCode,
+          localMatch: false,
+          proximityMatch: true,
+          distanceMiles: best.distance,
+          isPrimary: best.number.isPrimary,
+          customerAreaCode,
+        };
+      }
+    }
+
+    // 3. primary fallback
+    return this.primaryFallback(pool, customerAreaCode);
+  }
+
+  private primaryFallback(pool: NumberPool, customerAreaCode: string | null): NumberSelection | null {
+    const primary = pool.primaryNumber ?? pool.numbers.find((n) => n.isPrimary && n.isActive);
+    if (!primary) return null;
+    return {
+      phoneNumber: primary.phoneNumber,
+      areaCode: primary.areaCode,
+      localMatch: false,
+      proximityMatch: false,
+      isPrimary: true,
+      customerAreaCode: customerAreaCode ?? undefined,
+    };
+  }
+}

--- a/packages/dialer/src/types.ts
+++ b/packages/dialer/src/types.ts
@@ -1,31 +1,116 @@
-// @consuelo/dialer — types
+/** Twilio credentials configuration */
+export interface TwilioCredentials {
+  accountSid: string;
+  authToken: string;
+  apiKey?: string;
+  apiSecret?: string;
+  twimlAppSid?: string;
+}
 
+/** Dialer configuration */
 export interface DialerConfig {
-  provider?: "twilio";
-  accountSid?: string;
-  authToken?: string;
-  defaultCallerId?: string;
-  localPresence?: boolean;
+  provider?: 'twilio';
+  credentials?: TwilioCredentials;
+  /** Base URL for webhooks (status callbacks, TwiML) */
+  baseUrl?: string;
+  /** Default caller ID number */
+  defaultNumber?: string;
 }
 
-export interface CallOptions {
+/** Options for initiating a call */
+export interface DialOptions {
+  /** Number to call */
   to: string;
-  from?: string;
-  callerId?: string;
-  localPresence?: boolean;
-}
-
-export interface CallResult {
-  callSid: string;
-  status: string;
+  /** Caller's personal number (agent's phone) */
   from: string;
-  to: string;
-  startedAt: Date;
+  /** Manually selected outbound number (overrides auto-selection) */
+  callerIdNumber?: string;
+  /** User ID for the agent making the call */
+  userId: string;
+  /** Enable double-dial retry on no-answer */
+  doubleDial?: boolean;
+  /** Enable local presence number selection */
+  localPresence?: boolean;
+  /** Status callback URL */
+  statusCallbackUrl?: string;
 }
 
-export interface DialerProvider {
-  dial(options: CallOptions): Promise<CallResult>;
-  hangup(callSid: string): Promise<void>;
-  getToken(userId: string): Promise<string>;
-  provisionNumber(areaCode: string): Promise<string>;
+/** Result of a dial() call */
+export interface DialResult {
+  success: boolean;
+  callSid?: string;
+  fromNumber?: string;
+  selectionMethod?: 'manual' | 'primary' | 'local_presence' | 'primary_fallback' | 'system_default';
+  error?: string;
+}
+
+/** Result of a hangup() call */
+export interface HangupResult {
+  success: boolean;
+  callSid: string;
+  error?: string;
+}
+
+/** Twilio voice token for browser calling */
+export interface VoiceToken {
+  token: string;
+  identity: string;
+  ttl: number;
+}
+
+/** Options for provisioning a phone number */
+export interface ProvisionNumberOptions {
+  /** Area code to search for */
+  areaCode: string;
+  /** Specific number to provision (if known) */
+  phoneNumber?: string;
+  /** Friendly name for the number */
+  friendlyName?: string;
+  /** Voice webhook URL */
+  voiceUrl?: string;
+  /** SMS webhook URL */
+  smsUrl?: string;
+}
+
+/** Result of provisioning a number */
+export interface ProvisionResult {
+  success: boolean;
+  phoneNumber?: string;
+  sid?: string;
+  areaCode?: string;
+  error?: string;
+}
+
+/** Phone number with metadata */
+export interface PhoneNumber {
+  phoneNumber: string;
+  areaCode: string;
+  isPrimary: boolean;
+  isActive: boolean;
+  city?: string;
+  state?: string;
+  latitude?: number;
+  longitude?: number;
+  twilioSid?: string;
+  friendlyName?: string;
+}
+
+/** Local presence number selection result */
+export interface NumberSelection {
+  phoneNumber: string;
+  areaCode: string;
+  localMatch: boolean;
+  proximityMatch: boolean;
+  distanceMiles?: number;
+  isPrimary: boolean;
+  customerAreaCode?: string;
+}
+
+/** Caller ID lock record */
+export interface CallerIdLock {
+  phoneNumber: string;
+  userId: string;
+  callSid: string;
+  acquiredAt: Date;
+  expiresAt: Date;
 }

--- a/packages/dialer/src/types.ts
+++ b/packages/dialer/src/types.ts
@@ -1,0 +1,31 @@
+// @consuelo/dialer — types
+
+export interface DialerConfig {
+  provider?: "twilio";
+  accountSid?: string;
+  authToken?: string;
+  defaultCallerId?: string;
+  localPresence?: boolean;
+}
+
+export interface CallOptions {
+  to: string;
+  from?: string;
+  callerId?: string;
+  localPresence?: boolean;
+}
+
+export interface CallResult {
+  callSid: string;
+  status: string;
+  from: string;
+  to: string;
+  startedAt: Date;
+}
+
+export interface DialerProvider {
+  dial(options: CallOptions): Promise<CallResult>;
+  hangup(callSid: string): Promise<void>;
+  getToken(userId: string): Promise<string>;
+  provisionNumber(areaCode: string): Promise<string>;
+}

--- a/packages/dialer/tsconfig.json
+++ b/packages/dialer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/metering/package.json
+++ b/packages/metering/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@consuelo/metering",
+  "version": "0.0.1",
+  "description": "Usage tracking, API key management, and billing",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/metering/src/index.ts
+++ b/packages/metering/src/index.ts
@@ -1,4 +1,149 @@
-// @consuelo/metering
-// Usage tracking, API key management, and billing
+import * as crypto from 'node:crypto';
 
-export {};
+/** API key record */
+export interface ApiKey {
+  id: string;
+  userId: string;
+  prefix: string; // "sk_live_abc..." (first 12 chars)
+  hash: string; // SHA-256 of full key
+  mode: 'live' | 'test';
+  scope: 'full' | 'readonly';
+  name?: string;
+  createdAt: string;
+  revokedAt?: string;
+}
+
+/** Usage record */
+export interface UsageRecord {
+  id: string;
+  apiKeyId: string;
+  userId: string;
+  type: 'call_minute' | 'coaching_request' | 'transcription_minute' | 'analytics_request';
+  quantity: number;
+  costCents: number;
+  timestamp: string;
+}
+
+/** User balance */
+export interface Balance {
+  userId: string;
+  balanceCents: number;
+  spendLimitCents: number;
+  autoTopUp: boolean;
+  topUpAmountCents: number;
+  topUpThresholdCents: number;
+}
+
+/** Usage query */
+export interface UsageQuery {
+  userId: string;
+  startDate?: string;
+  endDate?: string;
+  type?: UsageRecord['type'];
+}
+
+/** Storage interface for metering data */
+export interface MeteringStore {
+  saveApiKey(key: ApiKey): Promise<void>;
+  getApiKeyByHash(hash: string): Promise<ApiKey | null>;
+  listApiKeys(userId: string): Promise<ApiKey[]>;
+  revokeApiKey(id: string): Promise<void>;
+
+  recordUsage(record: UsageRecord): Promise<void>;
+  getUsage(query: UsageQuery): Promise<UsageRecord[]>;
+
+  getBalance(userId: string): Promise<Balance | null>;
+  updateBalance(userId: string, balanceCents: number): Promise<void>;
+}
+
+// Default cost per unit in cents
+const COSTS: Record<UsageRecord['type'], number> = {
+  call_minute: 3,          // $0.03/min
+  coaching_request: 1,     // $0.01/request
+  transcription_minute: 2, // $0.02/min
+  analytics_request: 1,    // $0.01/request
+};
+
+/**
+ * Metering — API key management, usage tracking, and balance management.
+ */
+export class Metering {
+  constructor(private store: MeteringStore) {}
+
+  /** Generate a new API key. Returns the full key (only shown once). */
+  async createKey(userId: string, opts: { mode?: 'live' | 'test'; scope?: 'full' | 'readonly'; name?: string } = {}): Promise<{ key: string; record: ApiKey }> {
+    const mode = opts.mode ?? 'live';
+    const raw = crypto.randomBytes(24).toString('base64url');
+    const fullKey = `sk_${mode}_${raw}`;
+    const hash = crypto.createHash('sha256').update(fullKey).digest('hex');
+
+    const record: ApiKey = {
+      id: crypto.randomUUID(),
+      userId,
+      prefix: fullKey.slice(0, 12) + '...',
+      hash,
+      mode,
+      scope: opts.scope ?? 'full',
+      name: opts.name,
+      createdAt: new Date().toISOString(),
+    };
+
+    await this.store.saveApiKey(record);
+    return { key: fullKey, record };
+  }
+
+  /** Validate an API key. Returns the key record or null. */
+  async validateKey(key: string): Promise<ApiKey | null> {
+    const hash = crypto.createHash('sha256').update(key).digest('hex');
+    const record = await this.store.getApiKeyByHash(hash);
+    if (!record || record.revokedAt) return null;
+    return record;
+  }
+
+  async listKeys(userId: string): Promise<ApiKey[]> {
+    return this.store.listApiKeys(userId);
+  }
+
+  async revokeKey(id: string): Promise<void> {
+    return this.store.revokeApiKey(id);
+  }
+
+  /** Record a usage event and deduct from balance. Returns false if insufficient balance. */
+  async recordUsage(apiKeyId: string, userId: string, type: UsageRecord['type'], quantity = 1): Promise<boolean> {
+    const costCents = COSTS[type] * quantity;
+    const balance = await this.store.getBalance(userId);
+
+    if (balance && balance.balanceCents < costCents) return false;
+
+    await this.store.recordUsage({
+      id: crypto.randomUUID(),
+      apiKeyId,
+      userId,
+      type,
+      quantity,
+      costCents,
+      timestamp: new Date().toISOString(),
+    });
+
+    if (balance) {
+      const newBalance = balance.balanceCents - costCents;
+      await this.store.updateBalance(userId, newBalance);
+
+      // Auto top-up check
+      if (balance.autoTopUp && newBalance <= balance.topUpThresholdCents) {
+        await this.store.updateBalance(userId, newBalance + balance.topUpAmountCents);
+        // In production: trigger Stripe charge here
+      }
+    }
+
+    return true;
+  }
+
+  async getUsage(query: UsageQuery): Promise<UsageRecord[]> {
+    return this.store.getUsage(query);
+  }
+
+  async getBalance(userId: string): Promise<Balance | null> {
+    return this.store.getBalance(userId);
+  }
+}

--- a/packages/metering/src/index.ts
+++ b/packages/metering/src/index.ts
@@ -1,0 +1,4 @@
+// @consuelo/metering
+// Usage tracking, API key management, and billing
+
+export {};

--- a/packages/metering/tsconfig.json
+++ b/packages/metering/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@consuelo/sdk",
+  "version": "0.0.1",
+  "description": "Unified re-export of all Consuelo SDK packages",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@consuelo/dialer": "workspace:*",
+    "@consuelo/coaching": "workspace:*",
+    "@consuelo/analytics": "workspace:*",
+    "@consuelo/contacts": "workspace:*"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,10 +11,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@consuelo/dialer": "workspace:*",
-    "@consuelo/coaching": "workspace:*",
-    "@consuelo/analytics": "workspace:*",
-    "@consuelo/contacts": "workspace:*"
+    "@consuelo/dialer": "*",
+    "@consuelo/coaching": "*",
+    "@consuelo/analytics": "*",
+    "@consuelo/contacts": "*"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,7 +1,7 @@
-// @consuelo/sdk
-// Unified re-export of all Consuelo SDK packages
+// @consuelo/sdk — unified re-export of all Consuelo SDK packages
+// Use namespaced imports to avoid collisions between packages
 
-export * from "@consuelo/dialer";
-export * from "@consuelo/coaching";
-export * from "@consuelo/analytics";
-export * from "@consuelo/contacts";
+export * as dialer from '@consuelo/dialer';
+export * as coaching from '@consuelo/coaching';
+export * as analytics from '@consuelo/analytics';
+export * as contacts from '@consuelo/contacts';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,7 @@
+// @consuelo/sdk
+// Unified re-export of all Consuelo SDK packages
+
+export * from "@consuelo/dialer";
+export * from "@consuelo/coaching";
+export * from "@consuelo/analytics";
+export * from "@consuelo/contacts";

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@consuelo/workspace",
+  "version": "0.0.1",
+  "description": "Workspace system with SQLite database and REST API",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "better-sqlite3": ">=9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "better-sqlite3": {
+      "optional": true
+    }
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -1,0 +1,201 @@
+/** Research entry */
+export interface Research {
+  id: string;
+  title: string;
+  content: string;
+  status: 'active' | 'archived' | 'draft';
+  tags: string[];
+  sourceUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Cron job record */
+export interface CronJob {
+  id: string;
+  name: string;
+  command: string;
+  schedule: string;
+  lastRun?: string;
+  lastStatus?: 'success' | 'failed';
+  lastOutput?: string;
+  createdAt: string;
+}
+
+/** Project record */
+export interface Project {
+  id: string;
+  name: string;
+  description: string;
+  status: 'active' | 'archived';
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Decision record */
+export interface Decision {
+  id: string;
+  title: string;
+  context: string;
+  decision: string;
+  rationale: string;
+  tags: string[];
+  createdAt: string;
+}
+
+/** Dashboard config */
+export interface Dashboard {
+  id: string;
+  name: string;
+  config: Record<string, unknown>;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Query options */
+export interface QueryOptions {
+  status?: string;
+  tag?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** Paginated response */
+export interface PaginatedResponse<T> {
+  data: T[];
+  meta: { total: number; limit: number; offset: number };
+}
+
+/** Storage interface — users supply their own persistence */
+export interface WorkspaceStore {
+  // Research
+  createResearch(data: Omit<Research, 'id' | 'createdAt' | 'updatedAt'>): Promise<Research>;
+  getResearch(id: string): Promise<Research | null>;
+  listResearch(opts?: QueryOptions): Promise<PaginatedResponse<Research>>;
+  updateResearch(id: string, data: Partial<Research>): Promise<Research | null>;
+  deleteResearch(id: string): Promise<boolean>;
+
+  // Cron Jobs
+  createCronJob(data: Omit<CronJob, 'id' | 'createdAt'>): Promise<CronJob>;
+  getCronJob(id: string): Promise<CronJob | null>;
+  listCronJobs(opts?: QueryOptions): Promise<PaginatedResponse<CronJob>>;
+  updateCronJob(id: string, data: Partial<CronJob>): Promise<CronJob | null>;
+  deleteCronJob(id: string): Promise<boolean>;
+
+  // Projects
+  createProject(data: Omit<Project, 'id' | 'createdAt' | 'updatedAt'>): Promise<Project>;
+  getProject(id: string): Promise<Project | null>;
+  listProjects(opts?: QueryOptions): Promise<PaginatedResponse<Project>>;
+  updateProject(id: string, data: Partial<Project>): Promise<Project | null>;
+  deleteProject(id: string): Promise<boolean>;
+
+  // Decisions
+  createDecision(data: Omit<Decision, 'id' | 'createdAt'>): Promise<Decision>;
+  getDecision(id: string): Promise<Decision | null>;
+  listDecisions(opts?: QueryOptions): Promise<PaginatedResponse<Decision>>;
+  deleteDecision(id: string): Promise<boolean>;
+
+  // Dashboards
+  createDashboard(data: Omit<Dashboard, 'id' | 'createdAt' | 'updatedAt'>): Promise<Dashboard>;
+  getDashboard(id: string): Promise<Dashboard | null>;
+  listDashboards(opts?: QueryOptions): Promise<PaginatedResponse<Dashboard>>;
+  updateDashboard(id: string, data: Partial<Dashboard>): Promise<Dashboard | null>;
+  deleteDashboard(id: string): Promise<boolean>;
+}
+
+/**
+ * Workspace — structured data store for research, projects, decisions, cron jobs, and dashboards.
+ * Wraps a WorkspaceStore implementation (SQLite, in-memory, etc.)
+ */
+export class Workspace {
+  constructor(readonly store: WorkspaceStore) {}
+
+  // Research
+  async addResearch(data: Omit<Research, 'id' | 'createdAt' | 'updatedAt'>) { return this.store.createResearch(data); }
+  async getResearch(id: string) { return this.store.getResearch(id); }
+  async listResearch(opts?: QueryOptions) { return this.store.listResearch(opts); }
+  async updateResearch(id: string, data: Partial<Research>) { return this.store.updateResearch(id, data); }
+  async deleteResearch(id: string) { return this.store.deleteResearch(id); }
+
+  // Cron Jobs
+  async addCronJob(data: Omit<CronJob, 'id' | 'createdAt'>) { return this.store.createCronJob(data); }
+  async getCronJob(id: string) { return this.store.getCronJob(id); }
+  async listCronJobs(opts?: QueryOptions) { return this.store.listCronJobs(opts); }
+  async updateCronJob(id: string, data: Partial<CronJob>) { return this.store.updateCronJob(id, data); }
+  async deleteCronJob(id: string) { return this.store.deleteCronJob(id); }
+
+  // Projects
+  async addProject(data: Omit<Project, 'id' | 'createdAt' | 'updatedAt'>) { return this.store.createProject(data); }
+  async getProject(id: string) { return this.store.getProject(id); }
+  async listProjects(opts?: QueryOptions) { return this.store.listProjects(opts); }
+  async updateProject(id: string, data: Partial<Project>) { return this.store.updateProject(id, data); }
+  async deleteProject(id: string) { return this.store.deleteProject(id); }
+
+  // Decisions
+  async addDecision(data: Omit<Decision, 'id' | 'createdAt'>) { return this.store.createDecision(data); }
+  async getDecision(id: string) { return this.store.getDecision(id); }
+  async listDecisions(opts?: QueryOptions) { return this.store.listDecisions(opts); }
+  async deleteDecision(id: string) { return this.store.deleteDecision(id); }
+
+  // Dashboards
+  async addDashboard(data: Omit<Dashboard, 'id' | 'createdAt' | 'updatedAt'>) { return this.store.createDashboard(data); }
+  async getDashboard(id: string) { return this.store.getDashboard(id); }
+  async listDashboards(opts?: QueryOptions) { return this.store.listDashboards(opts); }
+  async updateDashboard(id: string, data: Partial<Dashboard>) { return this.store.updateDashboard(id, data); }
+  async deleteDashboard(id: string) { return this.store.deleteDashboard(id); }
+}
+
+/** SQL schema for creating workspace tables */
+export const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS research (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  content TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'draft',
+  tags TEXT NOT NULL DEFAULT '[]',
+  source_url TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS cron_jobs (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  command TEXT NOT NULL,
+  schedule TEXT NOT NULL,
+  last_run TEXT,
+  last_status TEXT,
+  last_output TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS projects (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS decisions (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  context TEXT NOT NULL DEFAULT '',
+  decision TEXT NOT NULL DEFAULT '',
+  rationale TEXT NOT NULL DEFAULT '',
+  tags TEXT NOT NULL DEFAULT '[]',
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS dashboards (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  config TEXT NOT NULL DEFAULT '{}',
+  is_active INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+`;

--- a/packages/workspace/tsconfig.json
+++ b/packages/workspace/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,8 +1,70 @@
 #!/bin/bash
 # Consuelo SDK installer
 # Usage: curl -fsSL consuelohq.com/install | bash
+set -euo pipefail
 
-set -e
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m'
 
-echo "consuelo sdk installer — not yet implemented"
-echo "for now: npm install @consuelo/sdk"
+info()  { echo -e "${GREEN}▸${NC} $1"; }
+warn()  { echo -e "${YELLOW}▸${NC} $1"; }
+error() { echo -e "${RED}✗${NC} $1"; exit 1; }
+
+echo -e "\n${BOLD}consuelo${NC} — AI-powered sales toolkit\n"
+
+# Detect OS
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+info "detected: $OS $ARCH"
+
+# Check for Node.js
+if ! command -v node &>/dev/null; then
+  error "node.js is required. install it from https://nodejs.org"
+fi
+
+NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
+if [ "$NODE_VERSION" -lt 18 ]; then
+  error "node.js 18+ required (found v$NODE_VERSION)"
+fi
+info "node $(node -v) ✓"
+
+# Detect package manager
+if command -v bun &>/dev/null; then
+  PM="bun"
+  INSTALL="bun add -g"
+elif command -v pnpm &>/dev/null; then
+  PM="pnpm"
+  INSTALL="pnpm add -g"
+elif command -v yarn &>/dev/null; then
+  PM="yarn"
+  INSTALL="yarn global add"
+else
+  PM="npm"
+  INSTALL="npm install -g"
+fi
+info "using $PM"
+
+# Install
+info "installing @consuelo/cli..."
+$INSTALL @consuelo/cli 2>/dev/null || {
+  warn "global install failed — trying npx instead"
+  echo -e "\nyou can use consuelo via npx:"
+  echo -e "  ${BOLD}npx consuelo init${NC}"
+  echo -e "  ${BOLD}npx consuelo call +1234567890${NC}\n"
+  exit 0
+}
+
+# Verify
+if command -v consuelo &>/dev/null; then
+  echo -e "\n${GREEN}✓${NC} consuelo installed successfully!\n"
+  echo -e "get started:"
+  echo -e "  ${BOLD}consuelo init${NC}        — set up credentials"
+  echo -e "  ${BOLD}consuelo call <num>${NC}  — make a call"
+  echo -e "  ${BOLD}consuelo status${NC}      — check config\n"
+else
+  warn "installed but 'consuelo' not in PATH"
+  echo -e "try: ${BOLD}npx consuelo init${NC}\n"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Consuelo SDK installer
+# Usage: curl -fsSL consuelohq.com/install | bash
+
+set -e
+
+echo "consuelo sdk installer — not yet implemented"
+echo "for now: npm install @consuelo/sdk"

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Consuelo Docs</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#000;--fg:#fff;--muted:#888;--border:#222;--code-bg:#111}
+@media(prefers-color-scheme:light){:root{--bg:#fff;--fg:#000;--muted:#666;--border:#ddd;--code-bg:#f5f5f5}}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--fg);line-height:1.7}
+a{color:var(--fg)}
+header{display:flex;align-items:center;justify-content:space-between;padding:1rem 2rem;border-bottom:1px solid var(--border)}
+.logo{font-weight:700;font-size:1.2rem;text-decoration:none}
+nav a{color:var(--muted);text-decoration:none;margin-left:1.5rem;font-size:.9rem}
+
+.layout{display:flex;max-width:1100px;margin:0 auto}
+.sidebar{width:220px;padding:2rem 1rem;border-right:1px solid var(--border);position:sticky;top:0;height:100vh;overflow-y:auto}
+.sidebar a{display:block;padding:.3rem .5rem;color:var(--muted);text-decoration:none;font-size:.9rem;border-radius:4px}
+.sidebar a:hover,.sidebar a.active{color:var(--fg);background:var(--code-bg)}
+.sidebar h4{color:var(--muted);font-size:.75rem;text-transform:uppercase;letter-spacing:.05em;margin:1.5rem .5rem .5rem;font-weight:600}
+
+.content{flex:1;padding:2rem 3rem;max-width:750px}
+.content h1{font-size:2rem;margin-bottom:1rem}
+.content h2{font-size:1.3rem;margin:2rem 0 .5rem;padding-top:1rem;border-top:1px solid var(--border)}
+.content p{color:var(--muted);margin-bottom:1rem}
+.content code{background:var(--code-bg);padding:.15rem .4rem;border-radius:3px;font-size:.85rem}
+.content pre{background:var(--code-bg);padding:1rem;border-radius:6px;overflow-x:auto;margin-bottom:1.5rem}
+.content pre code{background:none;padding:0}
+</style>
+</head>
+<body>
+
+<header>
+  <a href="/" class="logo">consuelo</a>
+  <nav>
+    <a href="/">Home</a>
+    <a href="/docs" style="color:var(--fg)">Docs</a>
+    <a href="https://github.com/consuelohq/consuelo-internal-agents">GitHub</a>
+  </nav>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    <h4>Getting Started</h4>
+    <a href="/docs" class="active">Introduction</a>
+    <a href="/docs/quickstart.html">Quickstart</a>
+    <a href="/docs/installation.html">Installation</a>
+
+    <h4>Packages</h4>
+    <a href="/docs/dialer.html">@consuelo/dialer</a>
+    <a href="/docs/coaching.html">@consuelo/coaching</a>
+    <a href="/docs/analytics.html">@consuelo/analytics</a>
+    <a href="/docs/contacts.html">@consuelo/contacts</a>
+    <a href="/docs/api.html">@consuelo/api</a>
+    <a href="/docs/cli.html">@consuelo/cli</a>
+
+    <h4>Guides</h4>
+    <a href="/docs/self-hosting.html">Self-hosting</a>
+    <a href="/docs/providers.html">LLM Providers</a>
+    <a href="/docs/webhooks.html">Webhooks</a>
+  </aside>
+
+  <main class="content">
+    <h1>Consuelo SDK Documentation</h1>
+    <p>Consuelo is an open source sales infrastructure SDK. It gives you AI-powered dialing, real-time coaching, call analytics, and contact management — as code.</p>
+
+    <h2>Quick Install</h2>
+    <pre><code>curl -fsSL consuelohq.com/install | bash</code></pre>
+    <p>Or install via npm:</p>
+    <pre><code>npm install @consuelo/sdk</code></pre>
+
+    <h2>Hello World</h2>
+    <pre><code>import { Coach } from '@consuelo/coaching';
+
+const coach = new Coach({ apiKey: process.env.GROQ_API_KEY });
+
+const tips = await coach.coach([
+  { role: 'customer', content: 'I'm not sure about the price...' },
+  { role: 'sales_rep', content: 'I understand. Let me walk you through the value.' },
+]);
+
+console.log(tips);</code></pre>
+
+    <h2>Packages</h2>
+    <p>Each module is independently installable:</p>
+    <pre><code>npm install @consuelo/dialer     # Twilio-powered dialer
+npm install @consuelo/coaching   # AI coaching engine
+npm install @consuelo/analytics  # Call analytics + transcription
+npm install @consuelo/contacts   # Contact + queue management
+npm install @consuelo/api        # REST API layer
+npm install @consuelo/cli        # CLI tool</code></pre>
+
+    <h2>Architecture</h2>
+    <p>Consuelo is a monorepo of composable packages. Use the unified <code>@consuelo/sdk</code> or pick individual modules:</p>
+    <pre><code>import { dialer, coaching, analytics, contacts } from '@consuelo/sdk';</code></pre>
+
+    <h2>Self-hosted vs Managed</h2>
+    <p>Self-host with your own Twilio + LLM keys, or use <a href="/zen">Consuelo Zen</a> for zero-config managed infrastructure.</p>
+  </main>
+</div>
+</body>
+</html>

--- a/site/enterprise.html
+++ b/site/enterprise.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Consuelo Enterprise — Sales infrastructure at scale</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#000;--fg:#fff;--muted:#888;--border:#222}
+@media(prefers-color-scheme:light){:root{--bg:#fff;--fg:#000;--muted:#666;--border:#ddd}}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--fg);line-height:1.6}
+a{color:var(--fg);text-decoration:none}
+header{display:flex;align-items:center;justify-content:space-between;padding:1rem 2rem;border-bottom:1px solid var(--border)}
+.logo{font-weight:700;font-size:1.2rem}
+nav{display:flex;gap:1.5rem;font-size:.9rem}
+nav a{color:var(--muted)}
+
+.hero{text-align:center;padding:6rem 2rem 3rem;max-width:600px;margin:0 auto}
+.hero h1{font-size:2.5rem;font-weight:700;letter-spacing:-.02em;margin-bottom:1rem}
+.hero p{color:var(--muted);font-size:1.1rem;margin-bottom:2rem}
+
+.features{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1px;background:var(--border);border-top:1px solid var(--border);border-bottom:1px solid var(--border)}
+.feature{background:var(--bg);padding:2rem}
+.feature h3{font-size:1rem;margin-bottom:.5rem}
+.feature p{color:var(--muted);font-size:.9rem}
+
+.contact-form{max-width:500px;margin:4rem auto;padding:2rem}
+.contact-form h2{text-align:center;margin-bottom:1.5rem;font-size:1.5rem}
+.contact-form label{display:block;color:var(--muted);font-size:.85rem;margin-bottom:.3rem;margin-top:1rem}
+.contact-form input,.contact-form textarea,.contact-form select{width:100%;padding:.6rem;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:.9rem;font-family:inherit}
+.contact-form textarea{height:100px;resize:vertical}
+.contact-form button{margin-top:1.5rem;width:100%;padding:.7rem;border:none;border-radius:6px;background:var(--fg);color:var(--bg);font-size:1rem;font-weight:600;cursor:pointer}
+
+footer{border-top:1px solid var(--border);padding:2rem;text-align:center;color:var(--muted);font-size:.8rem;margin-top:4rem}
+</style>
+</head>
+<body>
+
+<header>
+  <a href="/" class="logo">consuelo</a>
+  <nav>
+    <a href="/">Home</a>
+    <a href="/docs">Docs</a>
+    <a href="/enterprise" style="color:var(--fg)">Enterprise</a>
+    <a href="/zen">Zen</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <h1>Sales infrastructure at scale</h1>
+  <p>Dedicated infrastructure, custom integrations, SLA guarantees, and white-glove onboarding for teams that need more.</p>
+</section>
+
+<section class="features">
+  <div class="feature">
+    <h3>🏢 Dedicated infrastructure</h3>
+    <p>Single-tenant deployment in your cloud or ours. SOC 2 Type II, HIPAA available.</p>
+  </div>
+  <div class="feature">
+    <h3>🔗 Custom integrations</h3>
+    <p>Salesforce, HubSpot, custom CRM. We build the connectors your team needs.</p>
+  </div>
+  <div class="feature">
+    <h3>📊 Advanced analytics</h3>
+    <p>Team leaderboards, manager dashboards, custom reports, and data exports.</p>
+  </div>
+  <div class="feature">
+    <h3>🛡️ SLA guarantee</h3>
+    <p>99.9% uptime SLA with dedicated support engineer and 1-hour response time.</p>
+  </div>
+  <div class="feature">
+    <h3>🎓 White-glove onboarding</h3>
+    <p>Dedicated implementation team. We migrate your data and train your reps.</p>
+  </div>
+  <div class="feature">
+    <h3>🔒 Security & compliance</h3>
+    <p>SSO/SAML, audit logs, data residency options, and custom retention policies.</p>
+  </div>
+</section>
+
+<section class="contact-form">
+  <h2>Talk to sales</h2>
+  <form>
+    <label>Name</label>
+    <input type="text" placeholder="Your name" required>
+    <label>Work email</label>
+    <input type="email" placeholder="you@company.com" required>
+    <label>Company</label>
+    <input type="text" placeholder="Company name">
+    <label>Team size</label>
+    <select>
+      <option>1-10</option>
+      <option>11-50</option>
+      <option>51-200</option>
+      <option>200+</option>
+    </select>
+    <label>Tell us about your needs</label>
+    <textarea placeholder="What are you looking to build?"></textarea>
+    <button type="submit">Get in touch</button>
+  </form>
+</section>
+
+<footer>
+  <a href="/">Home</a> · <a href="/docs">Docs</a> · <a href="https://github.com/consuelohq/consuelo-internal-agents">GitHub</a>
+  <br><br>© 2026 Consuelo
+</footer>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Consuelo — The open source sales infrastructure</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#000;--fg:#fff;--muted:#888;--border:#222;--accent:#fff}
+@media(prefers-color-scheme:light){:root{--bg:#fff;--fg:#000;--muted:#666;--border:#ddd;--accent:#000}}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--fg);line-height:1.6}
+a{color:var(--fg);text-decoration:none}
+a:hover{opacity:.8}
+
+/* Header */
+header{display:flex;align-items:center;justify-content:space-between;padding:1rem 2rem;border-bottom:1px solid var(--border)}
+.logo{font-weight:700;font-size:1.2rem}
+nav{display:flex;gap:1.5rem;align-items:center;font-size:.9rem}
+nav a{color:var(--muted)}
+nav a:hover{color:var(--fg)}
+.gh-stars{display:inline-flex;align-items:center;gap:.3rem;border:1px solid var(--border);border-radius:6px;padding:.2rem .6rem;font-size:.8rem}
+
+/* Hero */
+.hero{text-align:center;padding:6rem 2rem 4rem;max-width:700px;margin:0 auto}
+.hero h1{font-size:3rem;font-weight:700;letter-spacing:-.02em;line-height:1.1;margin-bottom:1rem}
+.hero p{color:var(--muted);font-size:1.1rem;margin-bottom:2.5rem}
+
+/* Install tabs */
+.install{max-width:500px;margin:0 auto;border:1px solid var(--border);border-radius:8px;overflow:hidden}
+.install-tabs{display:flex;border-bottom:1px solid var(--border)}
+.install-tabs button{flex:1;background:none;border:none;color:var(--muted);padding:.5rem;cursor:pointer;font-size:.8rem;font-family:inherit}
+.install-tabs button.active{color:var(--fg);background:var(--border)}
+.install-cmd{display:flex;align-items:center;justify-content:space-between;padding:.8rem 1rem;font-family:'SF Mono',monospace;font-size:.85rem}
+.install-cmd code{opacity:.9}
+.install-cmd button{background:none;border:none;color:var(--muted);cursor:pointer;font-size:.8rem}
+
+/* Features */
+.features{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1px;background:var(--border);border-top:1px solid var(--border);border-bottom:1px solid var(--border)}
+.feature{background:var(--bg);padding:2rem}
+.feature h3{font-size:1rem;margin-bottom:.5rem}
+.feature p{color:var(--muted);font-size:.9rem}
+
+/* Social proof */
+.social{text-align:center;padding:4rem 2rem}
+.social .badges{display:flex;gap:1rem;justify-content:center;margin-top:1rem}
+.badge{border:1px solid var(--border);border-radius:20px;padding:.3rem 1rem;font-size:.8rem;color:var(--muted)}
+
+/* Email capture */
+.email-capture{text-align:center;padding:4rem 2rem;border-top:1px solid var(--border)}
+.email-capture h2{font-size:1.5rem;margin-bottom:.5rem}
+.email-capture p{color:var(--muted);margin-bottom:1.5rem}
+.email-form{display:flex;gap:.5rem;max-width:400px;margin:0 auto}
+.email-form input{flex:1;padding:.6rem 1rem;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:.9rem}
+.email-form button{padding:.6rem 1.5rem;border:none;border-radius:6px;background:var(--fg);color:var(--bg);cursor:pointer;font-size:.9rem;font-weight:600}
+
+/* Footer */
+footer{border-top:1px solid var(--border);padding:2rem;text-align:center;color:var(--muted);font-size:.8rem}
+footer a{color:var(--muted);margin:0 .5rem}
+</style>
+</head>
+<body>
+
+<header>
+  <a href="/" class="logo">consuelo</a>
+  <nav>
+    <a href="https://github.com/consuelohq/consuelo-internal-agents" class="gh-stars">★ GitHub</a>
+    <a href="/docs">Docs</a>
+    <a href="/enterprise">Enterprise</a>
+    <a href="/zen">Zen</a>
+    <a href="#install">Download</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <h1>The open source sales infrastructure</h1>
+  <p>AI-powered dialer, real-time coaching, and call analytics — as code. Build your sales stack with open primitives.</p>
+
+  <div class="install" id="install">
+    <div class="install-tabs">
+      <button class="active" onclick="setTab(this,'curl -fsSL consuelohq.com/install | bash')">curl</button>
+      <button onclick="setTab(this,'npm install -g @consuelo/cli')">npm</button>
+      <button onclick="setTab(this,'bun add -g @consuelo/cli')">bun</button>
+      <button onclick="setTab(this,'brew install consuelo')">brew</button>
+    </div>
+    <div class="install-cmd">
+      <code id="cmd">curl -fsSL consuelohq.com/install | bash</code>
+      <button onclick="navigator.clipboard.writeText(document.getElementById('cmd').textContent)">copy</button>
+    </div>
+  </div>
+</section>
+
+<section class="features">
+  <div class="feature">
+    <h3>🎯 AI-powered coaching</h3>
+    <p>Real-time sales coaching during live calls. Objection handling, buying signals, and actionable tips — powered by any LLM.</p>
+  </div>
+  <div class="feature">
+    <h3>📞 Built-in dialer</h3>
+    <p>Twilio-powered dialer with local presence, caller ID management, and queue-based power dialing.</p>
+  </div>
+  <div class="feature">
+    <h3>📊 Call analytics</h3>
+    <p>Sentiment analysis, key moments, performance metrics, and talk ratio — structured data from every call.</p>
+  </div>
+  <div class="feature">
+    <h3>🤖 Any LLM</h3>
+    <p>Groq, OpenAI, Anthropic, or bring your own. Swap providers with one line of config.</p>
+  </div>
+  <div class="feature">
+    <h3>👥 Contact management</h3>
+    <p>Queues, CSV import, search, and tagging. Everything you need to manage your pipeline.</p>
+  </div>
+  <div class="feature">
+    <h3>🔓 Open source</h3>
+    <p>MIT licensed. Self-host on your infrastructure or use our managed tier. Your data, your rules.</p>
+  </div>
+</section>
+
+<section class="social">
+  <p>Trusted by sales teams building the future</p>
+  <div class="badges">
+    <span class="badge">Open Source</span>
+    <span class="badge">MIT License</span>
+    <span class="badge">TypeScript</span>
+  </div>
+</section>
+
+<section class="email-capture">
+  <h2>Be the first to know</h2>
+  <p>Get notified when we launch new features and modules.</p>
+  <div class="email-form">
+    <input type="email" placeholder="you@company.com">
+    <button>Subscribe</button>
+  </div>
+</section>
+
+<footer>
+  <a href="https://github.com/consuelohq/consuelo-internal-agents">GitHub</a>
+  <a href="/docs">Docs</a>
+  <a href="#">Changelog</a>
+  <a href="#">Discord</a>
+  <a href="#">X</a>
+  <br><br>
+  © 2026 Consuelo. Open source sales infrastructure.
+</footer>
+
+<script>
+function setTab(btn, cmd) {
+  document.querySelectorAll('.install-tabs button').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  document.getElementById('cmd').textContent = cmd;
+}
+</script>
+</body>
+</html>

--- a/site/zen.html
+++ b/site/zen.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Consuelo Zen — Managed sales infrastructure</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#000;--fg:#fff;--muted:#888;--border:#222}
+@media(prefers-color-scheme:light){:root{--bg:#fff;--fg:#000;--muted:#666;--border:#ddd}}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:var(--bg);color:var(--fg);line-height:1.6}
+a{color:var(--fg);text-decoration:none}
+a:hover{opacity:.8}
+header{display:flex;align-items:center;justify-content:space-between;padding:1rem 2rem;border-bottom:1px solid var(--border)}
+.logo{font-weight:700;font-size:1.2rem}
+nav{display:flex;gap:1.5rem;font-size:.9rem}
+nav a{color:var(--muted)}
+
+.hero{text-align:center;padding:6rem 2rem 3rem;max-width:600px;margin:0 auto}
+.hero h1{font-size:2.5rem;font-weight:700;letter-spacing:-.02em;margin-bottom:1rem}
+.hero p{color:var(--muted);font-size:1.1rem;margin-bottom:2rem}
+.hero .cta{display:inline-block;padding:.7rem 2rem;border:1px solid var(--fg);border-radius:6px;font-weight:600;font-size:1rem}
+
+.tiers{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.5rem;max-width:900px;margin:0 auto;padding:2rem}
+.tier{border:1px solid var(--border);border-radius:8px;padding:2rem}
+.tier h3{font-size:1.2rem;margin-bottom:.5rem}
+.tier .price{font-size:2rem;font-weight:700;margin-bottom:1rem}
+.tier .price span{font-size:.9rem;font-weight:400;color:var(--muted)}
+.tier ul{list-style:none;margin-bottom:1.5rem}
+.tier ul li{padding:.3rem 0;color:var(--muted);font-size:.9rem}
+.tier ul li::before{content:"✓ ";color:var(--fg)}
+.tier .btn{display:block;text-align:center;padding:.6rem;border:1px solid var(--border);border-radius:6px;font-size:.9rem}
+.tier.featured{border-color:var(--fg)}
+.tier.featured .btn{background:var(--fg);color:var(--bg)}
+
+.compare{max-width:700px;margin:3rem auto;padding:2rem}
+.compare h2{text-align:center;margin-bottom:1.5rem;font-size:1.5rem}
+.compare table{width:100%;border-collapse:collapse}
+.compare th,.compare td{padding:.6rem;text-align:left;border-bottom:1px solid var(--border);font-size:.9rem}
+.compare th{color:var(--muted);font-weight:400}
+
+footer{border-top:1px solid var(--border);padding:2rem;text-align:center;color:var(--muted);font-size:.8rem;margin-top:4rem}
+</style>
+</head>
+<body>
+
+<header>
+  <a href="/" class="logo">consuelo</a>
+  <nav>
+    <a href="/">Home</a>
+    <a href="/docs">Docs</a>
+    <a href="/enterprise">Enterprise</a>
+    <a href="/zen" style="color:var(--fg)">Zen</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <h1>Zero config. Just sell.</h1>
+  <p>Consuelo Zen is the managed tier — we handle infrastructure, you handle conversations. Same open source SDK, hosted for you.</p>
+  <a href="#pricing" class="cta">Get started</a>
+</section>
+
+<section class="tiers" id="pricing">
+  <div class="tier">
+    <h3>Free</h3>
+    <div class="price">$0<span>/mo</span></div>
+    <ul>
+      <li>100 calls/month</li>
+      <li>Basic coaching (Groq)</li>
+      <li>Call analytics</li>
+      <li>1 user</li>
+      <li>Community support</li>
+    </ul>
+    <a href="#" class="btn">Start free</a>
+  </div>
+  <div class="tier featured">
+    <h3>Pro</h3>
+    <div class="price">$49<span>/mo per seat</span></div>
+    <ul>
+      <li>Unlimited calls</li>
+      <li>Advanced coaching (any LLM)</li>
+      <li>Full analytics + exports</li>
+      <li>Local presence dialing</li>
+      <li>Priority support</li>
+      <li>Custom playbooks</li>
+    </ul>
+    <a href="#" class="btn">Start trial</a>
+  </div>
+  <div class="tier">
+    <h3>Team</h3>
+    <div class="price">$99<span>/mo per seat</span></div>
+    <ul>
+      <li>Everything in Pro</li>
+      <li>Team analytics + leaderboards</li>
+      <li>Manager dashboard</li>
+      <li>CRM integrations</li>
+      <li>SSO</li>
+      <li>Dedicated support</li>
+    </ul>
+    <a href="#" class="btn">Contact sales</a>
+  </div>
+</section>
+
+<section class="compare">
+  <h2>Self-hosted vs Managed</h2>
+  <table>
+    <tr><th></th><th>Self-hosted (free)</th><th>Zen (managed)</th></tr>
+    <tr><td>Infrastructure</td><td>You manage</td><td>We manage</td></tr>
+    <tr><td>Updates</td><td>Manual</td><td>Automatic</td></tr>
+    <tr><td>Twilio account</td><td>Your own</td><td>Included</td></tr>
+    <tr><td>LLM keys</td><td>Your own</td><td>Included</td></tr>
+    <tr><td>Support</td><td>Community</td><td>Priority/Dedicated</td></tr>
+    <tr><td>Data</td><td>Your servers</td><td>SOC 2 compliant</td></tr>
+  </table>
+</section>
+
+<footer>
+  <a href="/">Home</a> · <a href="/docs">Docs</a> · <a href="https://github.com/consuelohq/consuelo-internal-agents">GitHub</a>
+  <br><br>© 2026 Consuelo
+</footer>
+</body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {
+      "dependsOn": ["^build"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## DEV-522: opensaas — consuelo SDK monorepo

scaffolds the consuelo-sdk turborepo monorepo with all 8 packages and type stubs for the core modules.

### what's in this PR

- **turborepo** config with npm workspaces
- **8 packages** with package.json, tsconfig, and index.ts stubs:
  - `@consuelo/dialer` — twilio-powered dialer with local presence
  - `@consuelo/coaching` — real-time AI sales coaching engine
  - `@consuelo/analytics` — call transcription + sentiment analysis
  - `@consuelo/contacts` — contact CRUD + queue management
  - `@consuelo/api` — unified REST API layer
  - `@consuelo/cli` — CLI tool (bin entry configured)
  - `@consuelo/metering` — usage tracking + billing
  - `@consuelo/sdk` — unified re-export of all packages
- **type stubs** for core 4 modules with provider interfaces (DialerProvider, CoachingProvider, StorageProvider)
- **shared tsconfig** (ES2022, strict, bundler resolution)
- **curl installer stub** at scripts/install.sh

### linked issues

parent: DEV-522

**core module extraction (build first):**
- DEV-510 — extract core dialer module
- DEV-511 — extract AI coaching engine
- DEV-512 — extract transcription + call analytics
- DEV-513 — extract contacts + queue management

**infrastructure layer (build second):**
- DEV-514 — build unified REST API layer
- DEV-515 — build CLI tool
- DEV-516 — create npm package + curl installer
- DEV-521 — build usage metering + API key management

**go-to-market (build third):**
- DEV-517 — build landing page (opencode.ai clone)
- DEV-518 — build managed tier page (zen clone)
- DEV-519 — build enterprise page
- DEV-520 — build documentation site

**other:**
- DEV-508 — build workspace system

### next steps

each sub-issue gets its own session. this PR is the foundation — future commits build on this scaffold.